### PR TITLE
The codeunit example code was meaningless

### DIFF
--- a/dev-itpro/developer/devenv-codeunit-object.md
+++ b/dev-itpro/developer/devenv-codeunit-object.md
@@ -23,15 +23,20 @@ Typing the shortcut `tcodeunit` will create the basic layout for a codeunit obje
 ## Codeunit example
 This codeunit example checks whether a given customer has registered a shoe size. If not, the customer is assigned a shoe size of 42.
 
+The codeunit can be used both as a direct call to `codeunit.run(customer)` or as a call to the procedure inside the codeunit `createcustomer.CheckSize(customer)`.
+
 ```
 codeunit 50113 CreateCustomer
 {
     trigger OnRun();
-    var
-        r: record Customer;
+    TableNo = Customer;
     begin
-        if not r.HasShoeSize() then
-            r.ShoeSize := 42;
+        CheckSize(Rec);
+    end;
+    procedure CheckSize(var Cust : Record Customer)
+    begin
+        if not Cust.HasSHoeSize() then
+            Cust.ShoeSize := 42;
     end;
 }
 

--- a/dev-itpro/developer/devenv-codeunit-object.md
+++ b/dev-itpro/developer/devenv-codeunit-object.md
@@ -35,7 +35,7 @@ codeunit 50113 CreateCustomer
     end;
     procedure CheckSize(var Cust : Record Customer)
     begin
-        if not Cust.HasSHoeSize() then
+        if not Cust.HasShoeSize() then
             Cust.ShoeSize := 42;
     end;
 }


### PR DESCRIPTION
The example used an unassigned and unassignable variable "r". The new example shows both ways a codeunit can be used.