### PR TITLE
Update Extension Automation Api filter to package_id

### DIFF
--- a/dev-itpro/administration/itpro-introduction-to-automation-apis.md
+++ b/dev-itpro/administration/itpro-introduction-to-automation-apis.md
@@ -149,7 +149,7 @@ There are two bound actions available on the **extensions** endpoint: `Microsoft
 Issue a [POST extension](dynamics-microsoft-automation-extension-post.md) using the bound actions. See the example below.
 
 ```json
-POST https://api.businesscentral.dynamics.com/v2.0/{environment name}/api/microsoft/automation/v1.0{apiVersion}/companies({companyId})//extensions({extensionId})/Microsoft.NAV.install
+POST https://api.businesscentral.dynamics.com/v2.0/{environment name}/api/microsoft/automation/v1.0{apiVersion}/companies({companyId})//extensions({packageId})/Microsoft.NAV.install
 
 Authorization: Bearer {token}
 ```


### PR DESCRIPTION
The documentation on extension automation API is a bit unclear and is confusing for some of the users (as per this [Github issue](https://github.com/microsoft/AL/issues/5353#issuecomment-542456928)), so I am updating the documentation with the correct parameter name for this API call.