### PR TITLE
Change "TextConst" to "Label"

### DIFF
--- a/dev-itpro/developer/devenv-table-object.md
+++ b/dev-itpro/developer/devenv-table-object.md
@@ -75,7 +75,7 @@ table 50104 Address
     }
 
     var
-        Msg: TextConst = 'Hello from my method';
+        Msg: Label 'Hello from my method';
 
     trigger OnInsert();
     begin


### PR DESCRIPTION
The outdated "TextConst" used in the table example should be changed to label.
The example can not be compiled, see https://github.com/MicrosoftDocs/dynamics365smb-devitpro-pb/issues/1205