### PR TITLE
"Default Dimension Entity" leaves the primary key fields blank during insert.

### DIFF
--- a/dev-itpro/upgrade/Upgrading-the-Data.md
+++ b/dev-itpro/upgrade/Upgrading-the-Data.md
@@ -275,7 +275,7 @@ A data upgrade runs the upgrade toolkit objects, such as upgrade codeunits and u
 1. Open the [!INCLUDE[adminshell](../developer/includes/adminshell.md)] as an administrator, and then run [Start-NavDataUpgrade](/powershell/module/microsoft.dynamics.nav.management/start-navdataupgrade) cmdlet as follows:  
 
     ```  
-    Start-NavDataUpgrade -ServerInstance ServerInstanceName> -FunctionExecutionMode Serial -ContinueOnError  
+    Start-NavDataUpgrade -ServerInstance <ServerInstanceName> -FunctionExecutionMode Serial -ContinueOnError  
     ```  
     
     Replace `<ServerInstanceName>` with the name of the [!INCLUDE[server](../developer/includes/server.md)] instance that is connected to the database.
@@ -292,7 +292,7 @@ A data upgrade runs the upgrade toolkit objects, such as upgrade codeunits and u
     Run the following command to get a list of any errors that have occurred:
 
     ``` 
-    Get-NAVDataUpgrade ServerInstanceName> -ErrorOnly
+    Get-NAVDataUpgrade -ServerInstance <ServerInstanceName> -ErrorOnly
     ``` 
 
     Resolve the errors before going to the next task.


### PR DESCRIPTION
BC16.2 Page 5509 "Default Dimension Entity" only uses the "Parent ID" field to identify the record.
During the INSERT there is no validation of the "Parent ID", so the actual primary key fields are left blank!
So please ensure that the standard page code does validate the "Parent ID" field during the OnInsertRecord trigger.

Workaround:

    [EventSubscriber(ObjectType::Page, Page::"Default Dimension Entity", 'OnInsertRecordEvent', '', true, true)]
    local procedure OnInsertDefDimEntity(var Rec: Record "Default Dimension"; var xRec: Record "Default Dimension"; BelowxRec: Boolean; var AllowInsert: Boolean)
    begin
        if (Rec."Table ID" = 0) or (Rec."No." = '') then
            Rec.Validate(ParentId);

        AllowInsert := (Rec."Table ID" > 0) and (Rec."No." <> '');
    end;

