### PR TITLE
Document system fields interaction with SetLoadFields and AddLoadFields

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
@@ -42,7 +42,7 @@ The FieldNo's of the fields to be loaded.
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 
 ## Remarks
-It is not necessary to include the following fields: Primary key, SystemId, and Audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy) since they are always selcted for loading.
+It is not necessary to include the following fields, because they are always selected for loading: Primary key, SystemId, and data audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy).
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 

--- a/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
@@ -42,6 +42,7 @@ The FieldNo's of the fields to be loaded.
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 
 ## Remarks
+It is not necessary to include the following fields: Primary key, SystemId, and Audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy) since they are always selcted for loading.
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 

--- a/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
@@ -45,6 +45,8 @@ The FieldNo's of the fields to be loaded.
 
 Calling SetLoadFields on a record without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
 
+It is not necessary to include the following fields: Primary key, SystemId, and Audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy) since they are always selcted for loading.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## Example

--- a/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
@@ -45,7 +45,7 @@ The FieldNo's of the fields to be loaded.
 
 Calling SetLoadFields on a record without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
 
-It is not necessary to include the following fields: Primary key, SystemId, and Audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy) since they are always selcted for loading.
+It is not necessary to include the following fields, because they are always selected for loading: Primary key, SystemId, and data audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy).
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 

--- a/dev-itpro/developer/methods-auto/recordref/recordref-addloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-addloadfields-method.md
@@ -43,6 +43,8 @@ The FieldNo's of the fields to be loaded.
 
 ## Remarks
 
+Calling SetLoadFields on a record without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## Example

--- a/dev-itpro/developer/methods-auto/recordref/recordref-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-setloadfields-method.md
@@ -43,7 +43,7 @@ The FieldNo's of the fields to be loaded.
 ## Remarks
 Calling SetLoadFields on a recordref without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
 
-It is not necessary to include the following fields: Primary key, SystemId, and Audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy) since they are always selcted for loading.
+It is not necessary to include the following fields, because they are always selected for loading: Primary key, SystemId, and data audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy).
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 

--- a/dev-itpro/developer/methods-auto/recordref/recordref-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-setloadfields-method.md
@@ -41,6 +41,9 @@ The FieldNo's of the fields to be loaded.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## Remarks
+Calling SetLoadFields on a recordref without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
+
+It is not necessary to include the following fields: Primary key, SystemId, and Audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy) since they are always selcted for loading.
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 


### PR DESCRIPTION
Adds a remark discouraging the adding/setting system fields for Partial Records.