### PR TITLE
fix script to enable premium in alignment with bcch

### DIFF
--- a/dev-itpro/developer/devenv-work-sandbox-entitlements.md
+++ b/dev-itpro/developer/devenv-work-sandbox-entitlements.md
@@ -81,10 +81,11 @@ First of all, you must override the `SetupNavUsers.ps1` by sharing a local folde
 # Invoke default behavior
 . (Join-Path $runPath $MyInvocation.MyCommand.Name)
  
-Get-NavServerUser -serverInstance NAV -tenant default |? LicenseType -eq "FullUser" | % {
+Get-NavServerUser -serverInstance $ServerInstance -tenant default |? LicenseType -eq "FullUser" | ForEach-Object {
     $UserId = $_.UserSecurityId
     Write-Host "Assign Premium plan for $($_.Username)"
-    sqlcmd -S 'localhostSQLEXPRESS' -d $DatabaseName -Q "INSERT INTO [dbo].[User Plan] ([Plan ID],[User Security ID]) VALUES ('{8e9002c0-a1d8-4465-b952-817d2948e6e2}','$userId')" | Out-Null
+    Invoke-Sqlcmd -ErrorAction Ignore -ServerInstance 'localhost\SQLEXPRESS' -Query "USE [$TenantId]
+    INSERT INTO [dbo].[User Plan$63ca2fa4-4f03-4f2b-a480-172fef340d3f] ([Plan ID],[User Security ID]) VALUES ('{8e9002c0-a1d8-4465-b952-817d2948e6e2}','$userId')"
 }
 ```
 


### PR DESCRIPTION
The script to enable premium no longer worked. I fixed it in alignment with https://github.com/microsoft/navcontainerhelper/blob/HEAD/ContainerHandling/New-NavContainer.ps1#L1412-L1422 which can be simplified because we know this is always the latest sandbox