### PR TITLE
Fix typo in X_FORWARDED_PROTO

### DIFF
--- a/dev-itpro/deployment/configure-iis.md
+++ b/dev-itpro/deployment/configure-iis.md
@@ -51,6 +51,6 @@ On the server farm in IIS, add or edit a routing rule to include a server variab
 
 |  Name  |  Value  |  Replace  |
 |--------|---------|-----------|
-|`HTTP_X_FORWARED_PROTO`|`http` or `https`|`true`|
+|`HTTP_X_FORWARDED_PROTO`|`http` or `https`|`true`|
 ## See Also  
  [Business Central Web Server Overview](web-server-overview.md)   


### PR DESCRIPTION
Fixed a typo.

### From
X_FORWARED_PROTO

### To
X_FORWAR**D**ED_PROTO