### PR TITLE
Expand documentation on runtime required fields for Partial Records

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
@@ -44,6 +44,7 @@ The FieldNo's of the fields to be loaded.
 
 ## Remarks
 It is not necessary to include the following fields, because they are always selected for loading: Primary key, SystemId, and data audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy).
+Depending on the runtime version, the runtime may require extra fields to be selected for loading. Which extra fields are necessary depends on the state of the record and table and table extension definition. E.g. fields which that are filtered on are always loaded, fields which are refered to in calcformulas in the current table or table extension definition, etc.
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 

--- a/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
@@ -47,6 +47,7 @@ The FieldNo's of the fields to be loaded.
 Calling SetLoadFields on a record without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
 
 It is not necessary to include the following fields, because they are always selected for loading: Primary key, SystemId, and data audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy).
+Depending on the runtime version, the runtime may require extra fields to be selected for loading. Which extra fields are necessary depends on the state of the record and table and table extension definition. E.g. fields which that are filtered on are always loaded, fields which are refered to in calcformulas in the current table or table extension definition, etc.
 
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 


### PR DESCRIPTION
Multiple customers have reported issues regarding extra fields being included in loads even when they don't specify it [example](https://github.com/microsoft/AL/issues/6674).

Expand the documentation around runtime necessary fields.

Note:
We could be more precise in specify which extra fields are needed, but since this is an implementation detail that may change in the future we have decided to just mention the two most common cases and leave the rest unspecified.
