### PR TITLE
Update tenant-admin-center-environments.md

### DIFF
--- a/dev-itpro/administration/tenant-admin-center-environments.md
+++ b/dev-itpro/administration/tenant-admin-center-environments.md
@@ -96,7 +96,7 @@ You can create an environment that is a copy of an existing environment, such as
 4. Specify a name for the new environment.
 5. Choose the **Create** action.
 
-When the process starts, you can go to the list of your environments and see the status of the new environment. At first, you'll see the new environment with the state **Copy queued**, which changes to **Copying**, and then **Active** once the new environment is fully up and running. The original environment that the new environment is based on remains active.  
+When the process starts, you can go to the list of your environments and see the status of the new environment. At first, you'll see the new environment with the state **Preparing**, and then **Active** once the new environment is fully up and running. Further status details of the copy operation can be found on the Operations page in the [!INCLUDE[prodadmincenter](../developer/includes/prodadmincenter.md)]. The original environment that the new environment is based on remains active.
 
 ### Environment copies
 


### PR DESCRIPTION
Docs falsely stated that Copy Queued and Copying are statuses on the Environment Details page in TAC. In reality the displayed status is always "Preparing", with a detailed status available on the Operations page. Updated docs to reflect this.