### PR TITLE
Update devenv-export-data-for-extension.md

### DIFF
--- a/dev-itpro/developer/devenv-export-data-for-extension.md
+++ b/dev-itpro/developer/devenv-export-data-for-extension.md
@@ -50,7 +50,7 @@ The data must be exported into files to be included in the extension. To use the
     > [!NOTE]  
     > Export each web service to a separate XML file.
 
-3. Add the exported web services files to the Visual Studio Code project that contains your extension. An exported web service XML file looks like that:
+3. Add the exported web services files to the Visual Studio Code project that contains your extension. An exported web service XML file looks like the following:
 
     ```XML
     <?xml version="1.0" encoding="utf-8"?>

--- a/dev-itpro/developer/devenv-export-data-for-extension.md
+++ b/dev-itpro/developer/devenv-export-data-for-extension.md
@@ -1,6 +1,6 @@
 ---
 title: "Adding data for Extensions"
-description: "How you can export data such as permisisons, web services, and table data for an extension."
+description: "How you can add data such as permisisons, web services, and table data for an extension."
 author: SusanneWindfeldPedersen
 ms.custom: na
 ms.date: 04/01/2021

--- a/dev-itpro/developer/devenv-export-data-for-extension.md
+++ b/dev-itpro/developer/devenv-export-data-for-extension.md
@@ -1,5 +1,5 @@
 ---
-title: "Exporting data for Extensions"
+title: "Adding data for Extensions"
 description: "How you can export data such as permisisons, web services, and table data for an extension."
 author: SusanneWindfeldPedersen
 ms.custom: na
@@ -12,7 +12,7 @@ ms.service: "dynamics365-business-central"
 ms.author: solsen
 ---
 
-# Exporting data for Extensions
+# Adding data for Extensions
 For your extension to run properly, configuration and starting data such as permission sets and table data may be needed. An extension can include the following types of data that can be imported for the tenant during the installation of the extension.
 
 - Permission sets
@@ -22,7 +22,7 @@ For your extension to run properly, configuration and starting data such as perm
 
 The data must be exported into files to be included in the extension. To use the export functions you must use a container sandbox environment for [!INCLUDE[d365fin_long_md](includes/d365fin_long_md.md)]. For more information, see [Get started with the Container Sandbox Development Environment](devenv-get-started-container-sandbox.md).
 
-## To export permission sets
+## To add permission sets
 1. Open the [!INCLUDE[bc_dev_shell](includes/bc_dev_shell.md)].
 2. Export the relevant permission set using the `Export-NAVAppPermissionSet` cmdlet to export the permission set to a file. For example, the following command exports the BASIC permission set.
 
@@ -40,7 +40,7 @@ The data must be exported into files to be included in the extension. To use the
     > With the latest version of [!INCLUDE[d365fin_long_md](includes/d365fin_long_md.md)] permissions are no longer defined as data in the application database. Permissions that can be created by using AL objects are called *system* permissions. For more information, see [Entitlements and Permission Sets Overview](devenv-entitlements-and-permissionsets-overview.md).
 
 
-## To export web services
+## To add web services
 
 1. Open the [!INCLUDE[bc_dev_shell](includes/bc_dev_shell.md)].
 2. Export the relevant web service using the `Export-NAVAppTenantWebService` cmdlet to export the web service to a file. The following command exports the Customer Card page.
@@ -50,9 +50,44 @@ The data must be exported into files to be included in the extension. To use the
     > [!NOTE]  
     > Export each web service to a separate XML file.
 
-3. Add the exported web services files to the Visual Studio Code project that contains your extension.
+3. Add the exported web services files to the Visual Studio Code project that contains your extension. An exported web service XML file looks like that:
 
-## To export table data 
+    ```XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <ExportedData>
+        <TenantWebServiceCollection>
+            <TenantWebService>
+                <ObjectType>Page</ObjectType>
+                <ObjectID>21</ObjectID>
+                <ServiceName>Customer</ServiceName>
+                <Published>true</Published>
+            </TenantWebService>
+        </TenantWebServiceCollection>
+    </ExportedData>
+    ```
+    
+    You may also merge multiple XML files into one:
+    ```XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <ExportedData>
+        <TenantWebServiceCollection>
+            <TenantWebService>
+                <ObjectType>Page</ObjectType>
+                <ObjectID>21</ObjectID>
+                <ServiceName>Customer</ServiceName>
+                <Published>true</Published>
+            </TenantWebService>
+            <TenantWebService>
+                <ObjectType>Page</ObjectType>
+                <ObjectID>26</ObjectID>
+                <ServiceName>Vendor</ServiceName>
+                <Published>true</Published>
+            </TenantWebService>
+        </TenantWebServiceCollection>
+    </ExportedData>
+    ```
+
+## To add table data 
 
 1. Open the [!INCLUDE[bc_dev_shell](includes/bc_dev_shell.md)].
 2. Export the relevant data using the `Export-NAVAppTableData` cmdlet to export the data to a file. This includes setting the path to a folder where you want the .navxdata file created. A data file in the format of `TAB<TABLEID>.navxdata` will be created. (Example: TAB10000.navxdata). 
@@ -79,7 +114,7 @@ The data must be exported into files to be included in the extension. To use the
     > [!WARNING]
     > An extension can only include table data for new tables that are added as part of the extension.
 
-## To export custom report layouts
+## To add custom report layouts
 
 1. Open the [!INCLUDE[bc_dev_shell](includes/bc_dev_shell.md)].
 2. Export the relevant report layouts using the `Export-NAVAppReportLayout` cmdlet to export to a file:


### PR DESCRIPTION
The old title was a bit misleading since the article covered also the part how to add the exported data into the project.
I've added code sample for web services XML files, so that users could add them manually (no need to run a script for a few web services), and their keywords are indexed.
This should be actually added also for permission sets.