### PR TITLE
NOTE about Profile Configuration vs Directives

### DIFF
--- a/dev-itpro/developer/directives/devenv-directives-in-al.md
+++ b/dev-itpro/developer/directives/devenv-directives-in-al.md
@@ -25,6 +25,9 @@ Any code can be made conditional, including table fields, and checked using a co
 > [!NOTE]  
 > Built-in symbols are currently not supported in AL. Symbols must be defined in a specific file or in the `app.json` file.
 
+> [!NOTE]  
+> User Personalization and Profile Configuration (including Profile copy) are not meant to work with directives, so platform just ignore/remove them when possible (#pragma, #region, #endregion) and fail with an error when not supported (#if, #elif, #define, etc).
+
 ## Conditional directives
 
 The following conditional preprocessor directives are supported in AL.

--- a/dev-itpro/developer/directives/devenv-directives-in-al.md
+++ b/dev-itpro/developer/directives/devenv-directives-in-al.md
@@ -26,7 +26,7 @@ Any code can be made conditional, including table fields, and checked using a co
 > Built-in symbols are currently not supported in AL. Symbols must be defined in a specific file or in the `app.json` file.
 
 > [!NOTE]  
-> User Personalization and Profile Configuration (including Profile copy) are not meant to work with directives, so platform just ignore/remove them when possible (#pragma, #region, #endregion) and fail with an error when not supported (#if, #elif, #define, etc).
+> User personalization and profile configuration (including profile copy) are not meant to work with directives, which means that they are ignored by the platform in the cases of #pragma, #region, #endregion and fail with an error when they are not supported for #if, #elif, #define, etc.
 
 ## Conditional directives
 


### PR DESCRIPTION
This NOTE is important. There have been already 2 requests and note is about merged PR 101662: [Designer] Handle gracefully preprocessor directives in AL code. 

Problem:
When the designer creates NavDesignerObjects based on the syntax nodes for the AL code loaded, some of the trivias (including directives and/or end of lines) are lost. The designer is then working with invalid AL code.

Solution:
The designer isn't meant to work with directives, so we should just ignore/remove them when possible (#pragma, #region, #endregion) and fail when not supported (#if, #elif, #define, etc).

Note:
The solution here targets User Personalization and Profile Configuration (including profile copy) and doesn't cover the scenario with a DEV extension (roundtrip from VS Code) because it would probably be too restrictive.

Related work item TFS 412380