### PR TITLE
Update diagnostics-with-limit-date-overview.md

### DIFF
--- a/dev-itpro/developer/diagnostics/diagnostics-with-limit-date-overview.md
+++ b/dev-itpro/developer/diagnostics/diagnostics-with-limit-date-overview.md
@@ -20,12 +20,12 @@ This topic lists all the warning diagnostics that will turn or have turned into 
 
 |Release|Diagnostics|
 |---------|-----------|
-|2023 release wave 1|- [AL0711](diagnostic-al711.md)<br/>|
-|2022 release wave 2|- [AL0660](diagnostic-al660.md)<br/>- [AL0677](diagnostic-al677.md)<br/>- [AL0697](diagnostic-al697.md)<br/>- [AL0715](diagnostic-al715.md)<br/>|
-|2022 release wave 1|- [AL0692](diagnostic-al692.md)<br/>- [AL0694](diagnostic-al694.md)<br/>|
-|2021 release wave 2|- [AL0613](diagnostic-al613.md)<br/>|
-|2021 release wave 1|- [AL0639](diagnostic-al639.md)<br/>|
-|2020 release wave 1|- [AL0559](diagnostic-al559.md)<br/>|
+|2023 release wave 1|- [AL0711](diagnostic-al711.md) A member of type {0} with name '{1}' is already defined in {2} '{3}' by the extension '{4}'. Duplicate member names are not allowed when defining CueActions.<br/>|
+|2022 release wave 2|- [AL0660](diagnostic-al660.md) The property '{0}' cannot be customized.<br/>- [AL0677](diagnostic-al677.md) The member '{0}' in object '{1}' cannot be declared as protected in object type '{2}'.<br/>- [AL0697](diagnostic-al697.md) Argument {0}: The argument should be a valid Field type.<br/>- [AL0715](diagnostic-al715.md) The {0} name '{1}' is reserved for future AL language features.<br/>|
+|2022 release wave 1|- [AL0692](diagnostic-al692.md) The primary key '{0}' on table '{1}' cannot be obsolete. All related properties will have no effect.<br/>- [AL0694](diagnostic-al694.md) The field '{0}' which is part of the primary key of table '{1}' cannot be obsolete. All related properties will have no effect.<br/>|
+|2021 release wave 2|- [AL0613](diagnostic-al613.md) Wrong signature. Correct signature for '{0}' is '{1}'.<br/>|
+|2021 release wave 1|- [AL0639](diagnostic-al639.md) 'Variant'  is not a valid column type for column '{0}' in report '{1}'.<br/>|
+|2020 release wave 1|- [AL0559](diagnostic-al559.md) A Part type page cannot contain other parts.<br/>|
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## See Also  


### PR DESCRIPTION
Added warning messages, else developers cannot easily determine whether the future turn into error is relevant for them. Clicking into each item individually would not provide an overview.