### PR TITLE
updated "See Also" sections to have line breaks

### DIFF
--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-callstack-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-callstack-method.md
@@ -40,6 +40,6 @@ The callstack where the ErrorInfo was collected.
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-controlname-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-controlname-method.md
@@ -43,6 +43,6 @@ The current control name of the ErrorInfo.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## See Also
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
-[Developing Extensions](../../devenv-dev-overview.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
+[Developing Extensions](../../devenv-dev-overview.md)  

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-create--method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-create--method.md
@@ -33,5 +33,5 @@ The created ErrorInfo.
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## See Also
 [ErrorInfo Data Type](errorinfo-data-type.md)  
-[Getting Started with AL](../devenv-get-started.md)
+[Getting Started with AL](../devenv-get-started.md)  
 [Developing Extensions](../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-create-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-create-method.md
@@ -63,6 +63,6 @@ Set of additional dimensions, specified as a dictionary. This parameter is optio
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-create-string-boolean-table-integer-integer-string-verbosity-dataclassification-dictionary[text,text]-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-create-string-boolean-table-integer-integer-string-verbosity-dataclassification-dictionary[text,text]-method.md
@@ -70,5 +70,5 @@ The created ErrorInfo.
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## See Also
 [ErrorInfo Data Type](errorinfo-data-type.md)  
-[Getting Started with AL](../devenv-get-started.md)
+[Getting Started with AL](../devenv-get-started.md)  
 [Developing Extensions](../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-customdimensions-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-customdimensions-method.md
@@ -45,6 +45,6 @@ The current custom dimensions of the ErrorInfo.
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-detailedmessage-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-detailedmessage-method.md
@@ -43,6 +43,6 @@ The current detailed message of the ErrorInfo.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## See Also
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-fieldno-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-fieldno-method.md
@@ -45,6 +45,6 @@ The current field ID of the ErrorInfo.
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-pageno-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-pageno-method.md
@@ -45,6 +45,6 @@ The current page number of the ErrorInfo.
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-recordid-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-recordid-method.md
@@ -45,6 +45,6 @@ The current record ID of the ErrorInfo.
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-systemid-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-systemid-method.md
@@ -43,6 +43,6 @@ The current system ID of the ErrorInfo.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## See Also
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)

--- a/dev-itpro/developer/methods-auto/errorinfo/errorinfo-tableid-method.md
+++ b/dev-itpro/developer/methods-auto/errorinfo/errorinfo-tableid-method.md
@@ -45,6 +45,6 @@ The current table ID of the ErrorInfo.
 ## See Also
 
 [Collecting Errors](../../devenv-error-collection.md)  
-[ErrorInfo Data Type](errorinfo-data-type.md)
-[Getting Started with AL](../../devenv-get-started.md)
+[ErrorInfo Data Type](errorinfo-data-type.md)  
+[Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)


### PR DESCRIPTION
Several pages in the ErrorInfo object had no line breaks in the "See Also" section, which made it hard to view and select the right link.