### PR TITLE
Update automation-apis-using-s2s-authentication.md

### DIFF
--- a/dev-itpro/administration/automation-apis-using-s2s-authentication.md
+++ b/dev-itpro/administration/automation-apis-using-s2s-authentication.md
@@ -72,7 +72,8 @@ Complete these steps to register an application in your Azure AD tenant for serv
     |Setting|Description|
     |-------|-----------|
     |Name|Specify a unique name for your application. |
-    |Supported account types| Select either <strong>Accounts in this organizational directory only (Microsoft only - Single tenant)</strong> or <strong>Accounts in any organizational directory (Any Azure AD directory - Multitenant)</strong>.|
+    |Supported account types| Select either <strong>Accounts in this organizational directory only (Microsoft only - Single tenant)</strong> or <strong>Accounts in any organizational directory (Any Azure AD directory - Multitenant)</strong>.| 
+    |Redirect URI|Set the redirect URI to <strong>https://businesscentral.dynamics.com/OAuthLanding.htm</strong>
 
 
     When completed, an **Overview** displays in the portal for the new application.


### PR DESCRIPTION
The redirect URI is necessary here, and API authorization requests will not succeed without it. I propose adding that explicitly here, as it is not obvious otherwise.