### PR TITLE
Changed LT0004 to LC0004

### DIFF
--- a/dev-itpro/administration/telemetry-company-lifecycle-trace.md
+++ b/dev-itpro/administration/telemetry-company-lifecycle-trace.md
@@ -147,7 +147,7 @@ Occurs when a company has been copied from another company successfully.
 |componentVersion|Specifies the version number of the component that emits telemetry (see the component dimension.)|
 |deprecatedKeys|Specifies a comma-separated list of all the keys that have been deprecated. The keys in this list are still supported but will eventually be removed in the next major release. We recommend that update any queries that use these keys to use the new key name.|
 |environmentType|Specifies the environment type for the tenant, such as **Production**, **Sandbox**, **Trial**. See [Environment Types](tenant-admin-center-environments.md#types-of-environments)|
-|eventId|**LT0004**|
+|eventId|**LC0004**|
 |result|**Success**|
 |serverExecutionTime|Specifies the amount of time it took the server to copy the company. The time has the format hh:mm:ss.sssssss.|
 |sqlExecutes|Specifies the number of SQL statements that were executed by the operation.|


### PR DESCRIPTION
Lifecycle signals are marked with prefix LC. LT was just a typo.