### PR TITLE
Highlighted in a NOTE the commit behavior

### DIFF
--- a/dev-itpro/developer/devenv-events-isolated.md
+++ b/dev-itpro/developer/devenv-events-isolated.md
@@ -25,7 +25,7 @@ Isolated events are implemented by separating each event subscriber into its own
 :::image-end:::
 
 > [!NOTE]  
->   Read-only transactions are allowed to call isolated events directly, but **write transactions should explicitly be committed before invoking an isolated event. Otherwise, the isolated event will be invoked like an normal event, that is, errors inside an event subscriber will cause the entire operation to fail**.
+> Read-only transactions are allowed to call isolated events directly, but **write transactions should explicitly be committed before invoking an isolated event. Otherwise, the isolated event will be invoked like an normal event, that is, errors inside an event subscriber will cause the entire operation to fail**.
 
 ### Rollback
 

--- a/dev-itpro/developer/devenv-events-isolated.md
+++ b/dev-itpro/developer/devenv-events-isolated.md
@@ -24,7 +24,8 @@ Isolated events are implemented by separating each event subscriber into its own
     When an event is raised, the platform gets the first event subscriber. When the event is isolated, an isolated transaction starts, then the event subscriber is invoked. If an error occurs, the transaction is rolled back, and the flow is repeated for the next event subscriber. Otherwise, the transaction is committed and the flow is repeated for the next event subscriber. 
 :::image-end:::
 
-Read-only transactions are allowed to call isolated events directly, but write transactions should explicitly be committed before invoking an isolated event. Otherwise, the isolated event will be invoked like an normal event, that is, errors inside an event subscriber will cause the entire operation to fail.
+> [!NOTE]  
+>   Read-only transactions are allowed to call isolated events directly, but **write transactions should explicitly be committed before invoking an isolated event. Otherwise, the isolated event will be invoked like an normal event, that is, errors inside an event subscriber will cause the entire operation to fail**.
 
 ### Rollback
 


### PR DESCRIPTION
This is a very important part related to Isolated Events that might not be highlighted as it should.
Below a comment from a support request "A suggestion for improvement on the documentation of Isolated Events:In my opinion, this limitation of Isolated Events is very important and should be highlighted in the documentation."

This commit is to move the description of this important constraint into an highlighted and bold note.