### PR TITLE
[API v2.0 - agedAccountsReceivable] Update request url to match EntitySetName

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_agedaccountsreceivable_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_agedaccountsreceivable_get.md
@@ -19,7 +19,7 @@ Retrieve the properties and relationships of an aged accounts receivable report 
 ## HTTP request
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 ```
-GET businesscentralPrefix/companies({id})/agedAccountsReceivable
+GET businesscentralPrefix/companies({id})/agedAccountsReceivables({customerId})
 ```
 
 ## Request headers
@@ -41,7 +41,7 @@ If successful, this method returns a ```200 OK``` response code and an **agedAcc
 Here is an example of the request.
 
 ```json
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/agedAccountsReceivable
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/agedAccountsReceivables({customerId})
 ```
 
 **Response**


### PR DESCRIPTION
Me personally would just go with the `customers({id})/agedAccountsReceivable`.

As in these examples, it simply won't work because it's based on the `EntitySetName = 'timeRegistrationEntries'`