### PR TITLE
FieldContentBuffer.Table.al must be removed

### DIFF
--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v20.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v20.md
@@ -186,6 +186,9 @@ You'll create two versions of this extension. The first version contains the tab
     > [!NOTE]
     > If the `--tableDataOnly` parameter isn't available, you'll need a later version ot the txt2al conversion tool. See [Prerequisites](#prereqs) for more information.
 
+    > [!NOTE]
+    > Remove FieldContentBuffer.Table.al (table 1754 "Field Content Buffer") from the target directory since this will be part of System Application extension.
+
 5. Make sure you have installed the latest AL Extension for Visual Studio Code from the version 20 DVD.
 
    For more information, see [Get Started with AL](../developer/devenv-get-started.md).
@@ -274,7 +277,6 @@ You'll create two versions of this extension. The first version contains the tab
     |table 7330 "Bin Content Buffer" |BinContentBuffer.Table.al|Remove any `TableRelation =` lines. |
     |table 265 "Document Entry"| DocumentEntry.Table.al|Remove any `TableRelation =` lines.|
     |table 338 "Entry Summary" |EntrySummary.Table.al|Remove line `AccessByPermission = TableData "Warehouse Source Filter" = R;`<br /><br />Remove any `TableRelation =` lines. |
-    |table 1754 "Field Content Buffer"|FieldContentBuffer.Table.al|Remove any `TableRelation =` lines. |
     |table 1670 "Option Lookup Buffer"|OptionLookupBuffer.Table.al |Remove any `TableRelation =` lines. |
 
     Starting in version 18, these tables have been changed to temporary tables. For now, you'll have to include these objects in the table migration extension; otherwise you'll have problems syncing the extension later.


### PR DESCRIPTION
FieldContentBuffer.Table.al must be removed from the list of tables generated through txt2al because of in version 20 and onwards it is now part of system application. This will not let the upgrade go through and elevate an exception like e.g.

Type: Microsoft.Dynamics.Nav.Types.Exceptions.NavAppObjectMetadataException
ErrorCode: -1
SuppressMessage: False
ContainsPersonalOrRestrictedInformation: False
DiagnosticsSuppress: True
MessageWithoutPrivateInformation: The application object of type 'Table' with the ID '1754' is defined in multiple apps. The apps are: bc14baseapptablesonly by My publisher 2.0.0.0; System Application by Microsoft 20.2.41144.41423.
SuppressExceptionCreatedEvent: False