### PR TITLE
Update record-transferfields-table-boolean-method.md

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-transferfields-table-boolean-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-transferfields-table-boolean-method.md
@@ -48,7 +48,7 @@ If this parameter is false, then neither the timestamp nor the Primary Key field
 
 The `TransferFields` method copies fields based on the field number on the fields. For each field in `Record` (the destination), the contents of the field that has the same field number in `FromRecord` (the source) will be copied, if such a field exists.
 
-The fields must have the *same data type* for the copying to succeed (text and code are convertible, other types are not). There must be room for the actual length of the contents of the field to be copied in the field to which it is to be copied. If any one of these conditions are not fulfilled, a runtime error will occur.
+The fields must have the *same data type* for the copying to succeed (text and code are convertible, other types are not). Enum fields are considered being the same data type even on different enum types. There must be room for the actual length of the contents of the field to be copied in the field to which it is to be copied. If any one of these conditions are not fulfilled, a runtime error will occur.
 
 > [!NOTE]  
 > Fields are assigned, such as `DestinationRecord.Field := SourceRecord.Field`, which will not call the OnValidate trigger on the destination field. To assist with validation when using the `TransferFields` method, the `TypeHelper` codeunit contains a `TransferFieldsWithValidate` method.


### PR DESCRIPTION
Added a remark that one may use transferfields even for differing enum fields (e.g. from enum "Sales Document Type" to enum "Purchase Document Type").