### PR TITLE
Moved deprecation notice to the top of the page

### DIFF
--- a/dev-itpro/developer/methods-auto/file/file-uploadintostream-string-string-string-text-instream-method.md
+++ b/dev-itpro/developer/methods-auto/file/file-uploadintostream-string-string-string-text-instream-method.md
@@ -23,6 +23,10 @@ Sends a file from the client computer to the corresponding server. The client co
 ```AL
 [Ok := ]  File.UploadIntoStream(DialogTitle: Text, FromFolder: Text, FromFilter: Text, var FromFile: Text, var InStream: InStream)
 ```
+
+> [!IMPORTANT]  
+> This method is deprecated from runtime 7.0. Use [File.UploadIntoStream Method](file-uploadintostream-string-instream-method.md) instead.
+
 > [!NOTE]
 > This method can be invoked without specifying the data type name.
 ## Parameters
@@ -56,12 +60,7 @@ The default file to upload to the service. The name displays in the dialog box f
 &emsp;Type: [Boolean](../boolean/boolean-data-type.md)  
 **true** if the operation was successful; otherwise **false**.   If you omit this optional return value and the operation does not execute successfully, a runtime error will occur.  
 
-
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
-
-> [!IMPORTANT]  
-> This method is deprecated from runtime 7.0. Use [File.UploadIntoStream Method](file-uploadintostream-string-instream-method.md) instead.
-
 
 ## See Also
 [File Data Type](file-data-type.md)


### PR DESCRIPTION
Having this notice at the bottom of the page leads to developers not seeing it. 
Moving it to the top of the page should help to prevent the use of this deprecated method.