### PR TITLE
Fix "see also" links showing on a single line

### DIFF
--- a/dev-itpro/developer/devenv-onafterdocumentready-event.md
+++ b/dev-itpro/developer/devenv-onafterdocumentready-event.md
@@ -215,11 +215,10 @@ end;
 ```
 
 ## See Also
-
 <!-- [Working With and Troubleshooting Payloads](devenv-reports-troubleshoot-printing.md)   -->
 <!-- [Developing Printer Extensions Overview](devenv-reports-printing.md)   -->
 <!-- [Creating a Printer Extension](devenv-reports-create-printer-extension.md)   -->
-[Events in AL](devenv-events-in-al.md)
-[Publishing Events](devenv-publishing-events.md)
-[Raising Events](devenv-raising-events.md)
+[Events in AL](devenv-events-in-al.md)\
+[Publishing Events](devenv-publishing-events.md)\
+[Raising Events](devenv-raising-events.md)\
 [Subscribing to Events](devenv-subscribing-to-events.md)

--- a/dev-itpro/developer/devenv-onafterdocumentready-event.md
+++ b/dev-itpro/developer/devenv-onafterdocumentready-event.md
@@ -218,7 +218,7 @@ end;
 <!-- [Working With and Troubleshooting Payloads](devenv-reports-troubleshoot-printing.md)   -->
 <!-- [Developing Printer Extensions Overview](devenv-reports-printing.md)   -->
 <!-- [Creating a Printer Extension](devenv-reports-create-printer-extension.md)   -->
-[Events in AL](devenv-events-in-al.md)\
-[Publishing Events](devenv-publishing-events.md)\
-[Raising Events](devenv-raising-events.md)\
-[Subscribing to Events](devenv-subscribing-to-events.md)
+[Events in AL](devenv-events-in-al.md)  
+[Publishing Events](devenv-publishing-events.md)  
+[Raising Events](devenv-raising-events.md)  
+[Subscribing to Events](devenv-subscribing-to-events.md)  


### PR DESCRIPTION
Fixed the links under the "see also" section showing up on a single line. 
These now show up on a new line per link, like on other pages.