### PR TITLE
[Testing the Advanced Sample Extension - Business Central] Fix app.json

### DIFF
--- a/dev-itpro/developer/devenv-extension-advanced-example-test.md
+++ b/dev-itpro/developer/devenv-extension-advanced-example-test.md
@@ -58,7 +58,7 @@ Before we can start writing the tests for the extension, we need to do the follo
 Our CustomerRewardsTest project will be referencing objects from the CustomerRewards project and so we will need to specify this in the `dependencies` setting in the CustomerRewardsTest project's app.json file. The `dependencies` setting takes a list of dependencies, where each dependency specifies the `appId`, `name`, `publisher`, and `version` of the base project/package that the current project/package will depend on.  
 
 > [!NOTE]  
-> Another prerequisite is to update the app.json with a dependency to the test toolkit.
+> Another prerequisite is to update the app.json with the dependencies of the test libraries used. In this case *Library Assert* and *Tests-TestLibraries*.
 
 ```json
  {
@@ -69,9 +69,20 @@ Our CustomerRewardsTest project will be referencing objects from the CustomerRew
       "name": "CustomerRewards", 
       "publisher": "Microsoft", 
       "version": "1.0.0.0" 
-    } 
-  ], 
-  "test": "13.0.0.0"
+    },
+    {
+        "id":  "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
+        "name":  "Library Assert",
+        "publisher":  "Microsoft",
+        "version":  "21.0.0.0"
+    },
+    {
+        "id":  "5d86850b-0d76-4eca-bd7b-951ad998e997",
+        "name":  "Tests-TestLibraries",
+        "publisher":  "Microsoft",
+        "version":  "21.0.0.0"
+    }
+  ]
    ...
 }
 ```

--- a/dev-itpro/developer/devenv-extension-advanced-example-test.md
+++ b/dev-itpro/developer/devenv-extension-advanced-example-test.md
@@ -74,13 +74,13 @@ Our CustomerRewardsTest project will be referencing objects from the CustomerRew
         "id":  "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
         "name":  "Library Assert",
         "publisher":  "Microsoft",
-        "version":  "21.0.0.0"
+        "version":  "19.0.0.0"
     },
     {
         "id":  "5d86850b-0d76-4eca-bd7b-951ad998e997",
         "name":  "Tests-TestLibraries",
         "publisher":  "Microsoft",
-        "version":  "21.0.0.0"
+        "version":  "19.0.0.0"
     }
   ]
    ...


### PR DESCRIPTION
The `test` property in the `app.json` file is no longer supported.
The official documentation says: `Version of the dependent test framework in the format X.Y.U.Z.
Note: This property is only supported for Business Central version 14 and earlier, where the base app is C/AL.` (Source: https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-json-files)

We need to add the dependencies to the `app.json` manually. This PR attempts to fix this.

Content: [Testing the Advanced Sample Extension - Business Central](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-extension-advanced-example-test)
Content Source: [dev-itpro/developer/devenv-extension-advanced-example-test.md](https://github.com/MicrosoftDocs/dynamics365smb-devitpro-pb/blob/main/dev-itpro/developer/devenv-extension-advanced-example-test.md)
Related Issue: #2509