### PR TITLE
[BC API 2.0] Fix incomeStatement endpoint

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_incomestatement_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_incomestatement_get.md
@@ -19,7 +19,7 @@ Retrieve the properties and relationships of an income statement report object f
 ## HTTP request
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 ```
-GET businesscentralPrefix/companies({id})/incomeStatement
+GET businesscentralPrefix/companies({id})/incomeStatements
 ```
 
 ## Request headers
@@ -40,7 +40,7 @@ If successful, this method returns a ```200 OK``` response code and an **incomeS
 
 Here is an example of the request.
 ```json
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/incomeStatement?$orderby=lineNumber&$filter=dateFilter ge 2019-01-01 and dateFilter le 2020-12-31
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/incomeStatements?$orderby=lineNumber&$filter=dateFilter ge 2019-01-01 and dateFilter le 2020-12-31
 ```
 
 **Response**
@@ -65,4 +65,4 @@ Here is an example of the response.
 
 ## See also
 [Tips for working with the APIs](../../../developer/devenv-connect-apps-tips.md)    
-[incomestatement](../resources/dynamics_incomestatement.md)    
+[incomeStatement](../resources/dynamics_incomestatement.md)    


### PR DESCRIPTION
Hi, currently the endpoint is set to incomeStatement, which throws the error:

```json
{
  "error": {
    "code": "BadRequest_NotFound",
    "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(9f462b5c-be8a-ed11-aad7-000d3aa934c9)/incomeStatement?tenant=default'."
  }
}
```

Updating from incomeStatement to **incomeStatements** fixes the issue.

---
Content site: https://learn.microsoft.com/de-de/dynamics365/business-central/dev-itpro/api-reference/v2.0/api/dynamics_incomestatement_get