### PR TITLE
[BC API 2.0 / paymentMethods] Remove read-only lastModifiedDateTime

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_paymentmethod_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_paymentmethod_create.md
@@ -48,8 +48,7 @@ Content-type: application/json
 {
     "id": "3a196a90-44e3-ea11-bb43-000d3a2feca1",
     "code": "ACCOUNT",
-    "displayName": "Payment on account",
-    "lastModifiedDateTime": "2020-08-21T00:48:51.487Z"
+    "displayName": "Payment on account"
 }
 ```
 


### PR DESCRIPTION
The property can not be used in the request body:

```json
{
  "error": {
    "code": "BadRequest",
    "message": "Control 'lastModifiedDateTime' is read-only.  CorrelationId:  d7facfa1-ea70-4349-b39f-4eefdac20c14."
  }
}
```

Remove the property **lastModifiedDateTime**.