### PR TITLE
[BC API 2.0 / PATCH paymentMethods] Remove comma

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_paymentmethod_update.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_paymentmethod_update.md
@@ -47,7 +47,7 @@ PATCH https://{businesscentralPrefix}/api/v2.0/companies({id})/paymentMethods({i
 Content-type: application/json
 
 {
-  "displayName": "Personal Check Payment",
+  "displayName": "Personal Check Payment"
 }
 ```
 


### PR DESCRIPTION
Using the comma in the request body ends up in an error:

```
{
  "error": {
    "code": "BadRequest",
    "message": "Invalid Request Body  CorrelationId:  e221d067-6b62-469f-862b-481d62d46e90."
  }
}
```

Removing it solves the problem:

```
{
  "id": "c4850c65-be8a-ed11-aad7-000d3aa934c9",
  "code": "ACCOUNT",
  "displayName": "Personal Check Payment",
  "lastModifiedDateTime": "2023-01-02T21:23:36.587Z"
}
```