### PR TITLE
[BC API 2.0 / POST salesOrders] Remove read-only field and not manual-nos properties

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrder_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrder_create.md
@@ -49,8 +49,6 @@ POST https://{businesscentralPrefix}/api/v2.0/companies({id})/salesOrders
 Content-type: application/json
 
 {
-  "id": "id-value",
-  "number": "1009",
   "orderDate": "2015-12-31",
   "customerNumber": "GL00000008",
   "currencyCode": "GBP",


### PR DESCRIPTION
Removed the fields **id** and **number**.

- **id** is read-only
- **number** manual Nos. in No. Series S-ORD

```
{
  "error": {
    "code": "Application_DialogException",
    "message": "You may not enter numbers manually. If you want to enter numbers manually, please activate Manual Nos. in No. Series S-ORD.  CorrelationId:  e5c26ced-b671-4b46-a2a5-2e1a4aff2bfd."
  }
}
```