### PR TITLE
[BC API 2.0] Update salesOrderLine

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -59,7 +59,6 @@ Content-type: application/json
     "unitPrice": 1397.3,
     "discountAmount": 0,
     "discountPercent": 0,
-    "discountAppliedBeforeTax": false,
     "amountExcludingTax": 16767.6,
     "taxCode": "FURNITURE",
     "taxPercent": 6.00002,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -59,7 +59,7 @@ Content-type: application/json
     "unitPrice": 1397.3,
     "discountAmount": 0,
     "discountPercent": 0,
-    "taxCode": "FURNITURE",
+    "taxCode": "STANDARD",
     "taxPercent": 6.00002,
     "totalTaxAmount": 1006.06,
     "amountIncludingTax": 17773.66,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -61,8 +61,6 @@ Content-type: application/json
     "discountPercent": 0,
     "taxCode": "STANDARD",
     "shipmentDate": "2020-04-02",
-    "shippedQuantity": 0,
-    "invoicedQuantity": 0,
     "invoiceQuantity": 12,
     "shipQuantity": 12,
     "itemVariantId": "00000000-0000-0000-0000-000000000000",

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -50,7 +50,6 @@ Content-type: application/json
 {
     "sequence": 10000,
     "itemId": "0ea6738a-44e3-ea11-bb43-000d3a2feca1",
-    "accountId": "00000000-0000-0000-0000-000000000000",
     "lineType": "Item",
     "lineObjectNumber": "1996-S",
     "description": "ATLANTA Whiteboard, base",

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -48,8 +48,6 @@ POST https://{businesscentralPrefix}/api/v2.0/companies({id})/salesOrders({id})/
 Content-type: application/json
 
 {
-    "id": "1e8cb9c0-44e3-ea11-bb43-000d3a2feca1",
-    "documentId": "960f5c9c-44e3-ea11-bb43-000d3a2feca1",
     "sequence": 10000,
     "itemId": "0ea6738a-44e3-ea11-bb43-000d3a2feca1",
     "accountId": "00000000-0000-0000-0000-000000000000",
@@ -94,6 +92,7 @@ Content-type: application/json
 
 {
     "id": "1e8cb9c0-44e3-ea11-bb43-000d3a2feca1",
+    "documentId": "960f5c9c-44e3-ea11-bb43-000d3a2feca1",
     "sequence": 10000,
     "itemId": "0ea6738a-44e3-ea11-bb43-000d3a2feca1",
     "accountId": "00000000-0000-0000-0000-000000000000",

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -75,7 +75,8 @@ Content-type: application/json
     "invoicedQuantity": 0,
     "invoiceQuantity": 12,
     "shipQuantity": 12,
-    "itemVariantId": "00000000-0000-0000-0000-000000000000"
+    "itemVariantId": "00000000-0000-0000-0000-000000000000",
+    "locationId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -59,7 +59,6 @@ Content-type: application/json
     "unitPrice": 1397.3,
     "discountAmount": 0,
     "discountPercent": 0,
-    "amountExcludingTax": 16767.6,
     "taxCode": "FURNITURE",
     "taxPercent": 6.00002,
     "totalTaxAmount": 1006.06,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -120,7 +120,8 @@ Content-type: application/json
     "invoicedQuantity": 0,
     "invoiceQuantity": 12,
     "shipQuantity": 12,
-    "itemVariantId": "00000000-0000-0000-0000-000000000000"
+    "itemVariantId": "00000000-0000-0000-0000-000000000000",
+    "locationId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "netTaxAmount": 1006.06,
     "netAmountIncludingTax": 17773.66,
     "shipmentDate": "2020-04-02",
     "shippedQuantity": 0,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "amountIncludingTax": 17773.66,
     "invoiceDiscountAllocation": 0,
     "netAmount": 16767.6,
     "netTaxAmount": 1006.06,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "totalTaxAmount": 1006.06,
     "amountIncludingTax": 17773.66,
     "invoiceDiscountAllocation": 0,
     "netAmount": 16767.6,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "netAmountIncludingTax": 17773.66,
     "shipmentDate": "2020-04-02",
     "shippedQuantity": 0,
     "invoicedQuantity": 0,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "invoiceDiscountAllocation": 0,
     "netAmount": 16767.6,
     "netTaxAmount": 1006.06,
     "netAmountIncludingTax": 17773.66,

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -94,7 +94,6 @@ Content-type: application/json
 
 {
     "id": "1e8cb9c0-44e3-ea11-bb43-000d3a2feca1",
-    "documentId": "960f5c9c-44e3-ea11-bb43-000d3a2feca1",
     "sequence": 10000,
     "itemId": "0ea6738a-44e3-ea11-bb43-000d3a2feca1",
     "accountId": "00000000-0000-0000-0000-000000000000",

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "netAmount": 16767.6,
     "netTaxAmount": 1006.06,
     "netAmountIncludingTax": 17773.66,
     "shipmentDate": "2020-04-02",

--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesOrderLine_create.md
@@ -60,7 +60,6 @@ Content-type: application/json
     "discountAmount": 0,
     "discountPercent": 0,
     "taxCode": "STANDARD",
-    "taxPercent": 6.00002,
     "totalTaxAmount": 1006.06,
     "amountIncludingTax": 17773.66,
     "invoiceDiscountAllocation": 0,


### PR DESCRIPTION
Removed id (not neccessary but I think the system itself can generate it).

Removed the documentId because we cannot modify it.

Added the locationId property.

Removed a lot of read-only properties (see commits / file changed)