### PR TITLE
Include tags for older version telemetry

### DIFF
--- a/dev-itpro/includes/include-lifecycle-telemetry-event-ids.md
+++ b/dev-itpro/includes/include-lifecycle-telemetry-event-ids.md
@@ -1,6 +1,7 @@
 | Event ID | Area | Message |
 |----------|-------------|-----------------|
 | AL0000E24 | Job Queue Lifecycle | [Job queue entry enqueued: {alJobQueueId} ](../administration/telemetry-job-queue-lifecycle-trace.md#enqueued) |
+| 'AL0000HE7' | Job Queue Lifecycle | [Job queue entry enqueued: {alJobQueueId} ](../administration/telemetry-job-queue-lifecycle-trace.md#enqueued) |
 | AL0000E25 | Job Queue Lifecycle | [Job queue entry started: {alJobQueueId} ](../administration/telemetry-job-queue-lifecycle-trace.md#started) |
 | AL0000E26 | Job Queue Lifecycle | [Job queue entry finished: {alJobQueueId} ](../administration/telemetry-job-queue-lifecycle-trace.md#finished) |
 |AL0000E3F|Configuration Package|[Configuration package export started: {alPackageCode}](../administration/telemetry-configuration-package-trace.md#exportstarted)|


### PR DESCRIPTION
Please also include these tags: 'AL0000HE7', 'AL0000FMG', 'AL0000HAK', 'AL0000FNY','AL0000HAI', as in older versions of BC 'AL0000E24','AL0000E25','AL0000E26' are not sufficient.