### PR TITLE
Remark about OnFindRecord and OnNextRecord

### DIFF
--- a/dev-itpro/developer/devenv-partial-records.md
+++ b/dev-itpro/developer/devenv-partial-records.md
@@ -161,6 +161,9 @@ Partial records are automatically applied based on the page’s metadata for Lis
 
 To extend which fields will be loaded, you can use the same approach as with OData pages.
 
+> [!NOTE]
+> OnFindRecord or OnNextRecord triggers conflicts with partial record feature hence if any of this trigger is defined in the metadata, partial record feature will not be applied and fall back to standard loading behavior.
+
 ### Table relation-based lookups
 
 Lookups that are based on table relations and not explicit lookup pages will automatically generate the set of fields to load by using the same logic as for determining which fields to shown. Because these lookups don't have a defined page, it isn’t possible, or necessary, to overrule the set of fields.

--- a/dev-itpro/developer/devenv-partial-records.md
+++ b/dev-itpro/developer/devenv-partial-records.md
@@ -162,7 +162,7 @@ Partial records are automatically applied based on the page’s metadata for Lis
 To extend which fields will be loaded, you can use the same approach as with OData pages.
 
 > [!NOTE]
-> OnFindRecord or OnNextRecord triggers conflicts with partial record feature hence if any of this trigger is defined in the metadata, partial record feature will not be applied and fall back to standard loading behavior.
+> OnFindRecord and OnNextRecord triggers conflict with partial record feature, so if either of these triggers is defined in the metadata, the partial record feature won't be applied and it fall back to standard loading behavior.
 
 ### Table relation-based lookups
 


### PR DESCRIPTION
If OnFindRecord and/or OnNextRecord are just defined in the List/ListPart (even if they do not have any code in it), platform will not apply any set load fields to load.  See also this request to refactor Item list page to improve performance. https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/433399

This remark is to generate awareness about this hidden platform behavior that have impact on performance when designing List/ListParts.