### PR TITLE
Update docs on extension type constraints

### DIFF
--- a/dev-itpro/developer/devenv-extension-types-and-scope.md
+++ b/dev-itpro/developer/devenv-extension-types-and-scope.md
@@ -120,8 +120,7 @@ In general, extensions are uniquely defined by their `id`. A specific version of
 
 - It is not possible to deploy a **Global app** and a **PTE** with the same `id`. During the upload of a PTE, we are validating that there is not a Global app with the same `id`. Currently, the AppSource validation process allows you to upload an app with the same `id` as an existing PTE to AppSource, but this means that it won't be possible to update the PTE anymore.
 
-- It is not possible to deploy a **Global app** and a **DEV** extension with the same `id` and `version`. When deploying the DEV version of a Global app from Visual Studio Code to a sandbox environment, for example, for development or troubleshooting, you must make sure that your DEV extension has a different `version` than what is published to AppSource. Similarly, after you are done developing/testing your extension, you should increase the `version` before submitting to AppSource. We also recommend changing the `id` of the app.
-- Due to some current limitations in our service, it is not possible to have an **Global app** and a **PTE** or **DEV** extension with the same `name`, `publisher`, and `version`, even if they have a different `id`.
+- It is not possible to deploy a **Global app** and a **DEV** extension with the same `id` and `version`. When deploying the DEV version of a Global app from Visual Studio Code to a sandbox environment, for example, for development or troubleshooting, you must make sure that your DEV extension has a different `version` than what is published to AppSource. Similarly, after you are done developing/testing your extension, you should increase the `version` before submitting to AppSource. 
 
 ## See Also
 


### PR DESCRIPTION
This brings our docs up to date with the current constraints on extension types.

For a few releases now we have supported having multiple apps with the same name/publisher as long as their IDs are different.

We also no longer require DEV apps to have a separate ID from global apps, all they need is to ensure that their versions do not conflict.