### PR TITLE
Revisited UseFilters note for better clarity.

### DIFF
--- a/dev-itpro/developer/methods-auto/system/system-geturl-clienttype-string-objecttype-integer-table-boolean-method.md
+++ b/dev-itpro/developer/methods-auto/system/system-geturl-clienttype-string-objecttype-integer-table-boolean-method.md
@@ -48,8 +48,9 @@ Specifies the Record variable that specifies which record to open.
 
 *[Optional] UseFilters*  
 &emsp;Type: [Boolean](../boolean/boolean-data-type.md)  
-Specifies whether to include filters that are defined on the object as a text string in the URL. Note, UseFilters is supported only for ClientType Desktop, OData, Phone, Tablet, Web, Windows, Current, Default, ODataV4, and Teams. An empty string is returned otherwise.  
-
+Specifies whether to include filters that are defined on the object as a text string in the URL.   
+> [!NOTE]
+> UseFilters is supported only for ClientType: Desktop, OData, Phone, Tablet, Web, Windows, ODataV4, Teams, Default and Current, when CurrentClientType is one of the ClientType mentioned.
 
 ## Return Value
 *String*  


### PR DESCRIPTION
The client types mentioned are possibly inccorect. Current refers to Session.CurrentClientType() and would not work within an API page, specifying ClientType::Current. This is the main reason to refactor the sentence.  Removed also the last part. The text is right regarding the parameter itself, but a false should not be counted as specified. Even false for e.g. GetFilters returns an empty string when using Api.