### PR TITLE
Set delay time also with an event in codeunit for

### DIFF
--- a/dev-itpro/api-reference/v2.0/dynamics-subscriptions.md
+++ b/dev-itpro/api-reference/v2.0/dynamics-subscriptions.md
@@ -127,6 +127,10 @@ The change type is indicated by the `"changeType"` parameter:
 
   Notifications aren't sent immediately when the record changes. By delaying notifications, [!INCLUDE[prod_short](../../includes/prod_short.md)] can ensure that only one notification is sent, even though the entity might have changed several times within a few seconds. By default, the system waits 30 seconds after the first change to an entity before it sends the notification. During the 30-second delay, if more than a 100 records are changed, a single `collection` notification is sent&mdash;otherwise, a separate notification is sent for each change. With Business Central on-premises, this time delay and notification limit are configurable.  
 
+  [!NOTE]
+  You can also subscribe on event `OnGetDelayTime` in codeunit `API Webhook Notification Mgt.` to change the delay time. 
+  Keep in mind that the Delay Time is in millisecconds.
+
 <!--
   > [!IMPORTANT]
   > Webhook notifications are used to trigger Power Automate flows from Business Central. However, Business Central currently doesn't support `collection` notifications for flows. So if an event changes more than 100 records with in 30 seconds, associated flows won't get triggered.

--- a/dev-itpro/api-reference/v2.0/dynamics-subscriptions.md
+++ b/dev-itpro/api-reference/v2.0/dynamics-subscriptions.md
@@ -128,8 +128,7 @@ The change type is indicated by the `"changeType"` parameter:
   Notifications aren't sent immediately when the record changes. By delaying notifications, [!INCLUDE[prod_short](../../includes/prod_short.md)] can ensure that only one notification is sent, even though the entity might have changed several times within a few seconds. By default, the system waits 30 seconds after the first change to an entity before it sends the notification. During the 30-second delay, if more than a 100 records are changed, a single `collection` notification is sent&mdash;otherwise, a separate notification is sent for each change. With Business Central on-premises, this time delay and notification limit are configurable.  
 
   > [!NOTE]
-  > You can also subscribe on event `OnGetDelayTime` in codeunit `API Webhook Notification Mgt.` to change the delay time. 
-  Keep in mind that the delay time is in millisecconds.
+  > You can also subscribe on event `OnGetDelayTime` in codeunit `API Webhook Notification Mgt.` to change the delay time. Keep in mind that the delay time is in millisecconds.
 
 <!--
   > [!IMPORTANT]

--- a/dev-itpro/api-reference/v2.0/dynamics-subscriptions.md
+++ b/dev-itpro/api-reference/v2.0/dynamics-subscriptions.md
@@ -127,9 +127,9 @@ The change type is indicated by the `"changeType"` parameter:
 
   Notifications aren't sent immediately when the record changes. By delaying notifications, [!INCLUDE[prod_short](../../includes/prod_short.md)] can ensure that only one notification is sent, even though the entity might have changed several times within a few seconds. By default, the system waits 30 seconds after the first change to an entity before it sends the notification. During the 30-second delay, if more than a 100 records are changed, a single `collection` notification is sent&mdash;otherwise, a separate notification is sent for each change. With Business Central on-premises, this time delay and notification limit are configurable.  
 
-  [!NOTE]
-  You can also subscribe on event `OnGetDelayTime` in codeunit `API Webhook Notification Mgt.` to change the delay time. 
-  Keep in mind that the Delay Time is in millisecconds.
+  > [!NOTE]
+  > You can also subscribe on event `OnGetDelayTime` in codeunit `API Webhook Notification Mgt.` to change the delay time. 
+  Keep in mind that the delay time is in millisecconds.
 
 <!--
   > [!IMPORTANT]


### PR DESCRIPTION
Cloud and onpremise.
In this way you can change the delay time (and not through a NST setting)