### PR TITLE
[BC API 2.0 | Get contactsInformation] Correct and update

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_contactinformation_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_contactinformation_get.md
@@ -1,5 +1,5 @@
 ---
-title: Get contactInformation  
+title: Get contactsInformation  
 description: Gets a contact information object in Dynamics 365 Business Central.
 author: SusanneWindfeldPedersen
 ms.topic: reference
@@ -23,8 +23,8 @@ Retrieves the properties and relationships of a contact information object for [
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 
 ```
-GET businesscentralPrefix/companies({id})/vendors({id})/contactsInformation({id})
-GET businesscentralPrefix/companies({id})/customers({id})/contactsInformation({id})
+GET businesscentralPrefix/companies({id})/vendors({id})/contactsInformation
+GET businesscentralPrefix/companies({id})/customers({id})/contactsInformation
 ```
 
 ## Request headers
@@ -39,7 +39,7 @@ Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a ```200 OK``` response code and a **contactInformation** object in the response body.
+If successful, this method returns a ```200 OK``` response code and a **contactsInformation** object in the response body.
 
 ## Example
 
@@ -48,7 +48,10 @@ If successful, this method returns a ```200 OK``` response code and a **contactI
 Here is an example of the request.
 
 ```json
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactInformation({id})
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {customerId} and relatedType eq 'Customer'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {vendorId} and relatedType eq 'Vendor'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {bankAccountId} and relatedType eq 'Bank Account'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {employeeId} and relatedType eq 'Employee'
 ```
 
 **Response**
@@ -56,12 +59,22 @@ Here is an example of the response.
 
 ```json
 {
-    "contactId" : "5d115c9c-44e3-ea11-bb43-000d3a2feca1",
-    "contactNumber" : "108001",
-    "contactName" : "Adatum Corporation",
-    "contactType" : "Company",
-    "relatedId" : "f2a5738a-44e3-ea11-bb43-000d3a2feca1",
-    "relatedType" : "Customer"
+    {
+        "contactId": "8f253caa-82de-ed11-884e-6045bdac97e2",
+        "contactNumber": "CT000001",
+        "contactName": "Adatum Corporation",
+        "contactType": "Company",
+        "relatedId": "8e253caa-82de-ed11-884e-6045bdac97e2",
+        "relatedType": "Customer"
+    },
+    {
+        "contactId": "91253caa-82de-ed11-884e-6045bdac97e2",
+        "contactNumber": "CT000002",
+        "contactName": "Robert Townes",
+        "contactType": "Person",
+        "relatedId": "8e253caa-82de-ed11-884e-6045bdac97e2",
+        "relatedType": "Customer"
+    }
 }
 ```
 


### PR DESCRIPTION
Hello there! Yes, I'm not finished yet. After a long break I'm back and ready to finish what I've started: updating all the BC API 2.0 endpoints:

Whenever I send a request as the following: `{{url}}/api/v2.0/companies({{companyId}})/contactInformation({{contactId}})?tenant={{tenant}}` I receive the following response error:

```json
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(7d95c69c-82de-ed11-884e-6045bdac97e2)/contactInformation(8f253caa-82de-ed11-884e-6045bdac97e2)?tenant=default'."
    }
}
```

After correcting the endpoint to `contactsInformation`: `{{url}}/api/v2.0/companies({{companyId}})/contactInformation({{contactId}})?tenant={{tenant}}` I receive the following response error:

```
{
    "error": {
        "code": "Application_DialogException",
        "message": "id type not specified.  CorrelationId:  1282d5e7-384c-4546-924e-62202a8125ed."
    }
}
```

Having a look at the source code: https://github.com/StefanMaron/MSDyn365BC.Code.History/blob/master/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2ContactsInformation.Page.al tells us that there is a `OnFindRecord` listening on the `relatedId` and `relatedType` fields/filters.

Thanks in advance! 🦦