### PR TITLE
[BC API 2.0 | companyInformation] Removed Navigation section

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_companyinformation.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_companyinformation.md
@@ -28,13 +28,6 @@ Represents a company information in [!INCLUDE[prod_short](../../../includes/prod
 |[GET companyInformation](../api/dynamics_companyinformation_get.md)|companyInformation|Gets a company information object.|
 |[PATCH companyInformation](../api/dynamics_companyinformation_update.md)|companyInformation|Updates a company information object.|
 
-
-## Navigation
-
-| Navigation |Return Type| Description |
-|:----------|:----------|:-----------------|
-|[countryRegion](dynamics_countryregion.md)|countryRegion |Gets the countryregion of the companyInformation.|
-
 ## Properties
 
 | Property           | Type   |Description     |


### PR DESCRIPTION
IMPORTANT: The suggested changes are in between the "Do not edit" section:
```
<!-- START>DO_NOT_EDIT -->
<!-- IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT. -->
<!-- IMPORTANT: END>DO_NOT_EDIT -->
```

I would assume, this needs to be change in a different repository.

---

Hello there,
it just looks like the Navigation section is no longer needed.

GET `baseUrl/companies(id)/companyInformation/countryRegion` results in

```
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "The request URI is not valid. Since the segment 'companyInformation' refers to a collection, this must be the last segment in the request URI or it must be followed by an function or action that can be bound to it otherwise all intermediate segments must refer to a single resource."
    }
}
```

The code doesn't show such section either: [StefanMaron/MSDyn365BC.Code.History/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2CompanyInformation.Page.al](StefanMaron/MSDyn365BC.Code.History/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2CompanyInformation.Page.al)

---

This is also true to the 
- contactInformation
- contact 

Could you verify this? Did I do something wrong in my requests?