### PR TITLE
[BC API 2.0 | contact] Removed countryRegion from Navigation

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_contact.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_contact.md
@@ -35,7 +35,6 @@ Represents a contact in [!INCLUDE[prod_short](../../../includes/prod_short.md)].
 |:----------|:----------|:-----------------|
 |[contactInformation](dynamics_contactinformation.md)|contactInformation |Gets the contactinformation of the contact.|
 |[contact](dynamics_contact.md)|NAV.contactBusinessRelation |Gets the contact of the contact.|
-|[countryRegion](dynamics_countryregion.md)|countryRegion |Gets the countryregion of the contact.|
 |[picture](dynamics_picture.md)|picture |Gets the picture of the contact.|
 
 ## Properties


### PR DESCRIPTION
IMPORTANT: The suggested changes are in between the "Do not edit" section:
```
<!-- START>DO_NOT_EDIT -->
<!-- IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT. -->
<!-- IMPORTANT: END>DO_NOT_EDIT -->
```

I would assume, this needs to be change in a different repository.

---

Hello there,
it just looks like the countryRegion cannot be used.

GET `baseUrl/companies(companyId)/contact(contactId)/countryRegion` results in

```
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f58755e3-4518-ee11-9cc3-6045bdc89477)/contacts(c26386fa-4518-ee11-9cc3-6045bdc89477)/countryRegion?tenant=default'."
    }
}
```

The code doesn't show such section either: [[StefanMaron/MSDyn365BC.Code.History/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2CompanyInformation.Page.al](https://github.com/StefanMaron/MSDyn365BC.Code.History/blob/master/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2Contacts.Page.al)](https://github.com/StefanMaron/MSDyn365BC.Code.History/blob/master/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2Contacts.Page.al)