### PR TITLE
[BC API 2.0 | Get contactsInformation] Optimize

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_contactinformation_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_contactinformation_get.md
@@ -25,8 +25,6 @@ Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md
 ```
 GET businesscentralPrefix/companies({id})/vendors({id})/contactsInformation
 GET businesscentralPrefix/companies({id})/customers({id})/contactsInformation
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {customerId} and relatedType eq 'Customer'
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {vendorId} and relatedType eq 'Vendor'
 GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {bankAccountId} and relatedType eq 'Bank Account'
 GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {employeeId} and relatedType eq 'Employee'
 ```

--- a/dev-itpro/api-reference/v2.0/api/dynamics_contactinformation_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_contactinformation_get.md
@@ -25,6 +25,10 @@ Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md
 ```
 GET businesscentralPrefix/companies({id})/vendors({id})/contactsInformation
 GET businesscentralPrefix/companies({id})/customers({id})/contactsInformation
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {customerId} and relatedType eq 'Customer'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {vendorId} and relatedType eq 'Vendor'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {bankAccountId} and relatedType eq 'Bank Account'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {employeeId} and relatedType eq 'Employee'
 ```
 
 ## Request headers
@@ -48,10 +52,7 @@ If successful, this method returns a ```200 OK``` response code and a **contacts
 Here is an example of the request.
 
 ```json
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {customerId} and relatedType eq 'Customer'
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {vendorId} and relatedType eq 'Vendor'
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {bankAccountId} and relatedType eq 'Bank Account'
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/contactsInformation$filter=relatedId eq {employeeId} and relatedType eq 'Employee'
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/customers({id})/contactsInformation
 ```
 
 **Response**


### PR DESCRIPTION
Trying to optimize the documentation page after the last PR:
- keep only 1 http request for the example
- still let the readers know about the related types: bankAccount and employee