### PR TITLE
[BC API 2.0 | opportunity] Removed Navigation section

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_opportunity.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_opportunity.md
@@ -30,13 +30,6 @@ Represents an opportunity in [!INCLUDE[prod_short](../../../includes/prod_short.
 |[POST opportunity](../api/dynamics_opportunity_create.md)|opportunity|Creates a opportunity object.|
 |[PATCH opportunity](../api/dynamics_opportunity_update.md)|opportunity|Updates a opportunity object.|
 
-
-## Navigation
-
-| Navigation |Return Type| Description |
-|:----------|:----------|:-----------------|
-|[contact](dynamics_contact.md)|contact |Gets the contact of the opportunity.|
-
 ## Properties
 
 | Property           | Type   |Description     |


### PR DESCRIPTION
IMPORTANT: The suggested changes are in between the "Do not edit" section:
```
<!-- START>DO_NOT_EDIT -->
<!-- IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT. -->
<!-- IMPORTANT: END>DO_NOT_EDIT -->
```

I would assume, this needs to be change in a different repository.

---

Hello there,
it just looks like the countryRegion cannot be used.

GET `baseUrl/companies(companyId)/opportunities(opportunityId)/contact` results in

```
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f58755e3-4518-ee11-9cc3-6045bdc89477)/opportunities(c55d8924-4618-ee11-9cc3-6045bdc89477)/contact?tenant=default'."
    }
}
```

The code doesn't show such section either: [[StefanMaron/MSDyn365BC.Code.History/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2CompanyInformation.Page.al](https://github.com/StefanMaron/MSDyn365BC.Code.History/blob/master/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2Opportunities.Page.al](https://github.com/StefanMaron/MSDyn365BC.Code.History/blob/master/APIV2/Source/_Exclude_APIV2_/src/pages/APIV2Opportunities.Page.al)