### PR TITLE
[BC API 2.0 | journal] Removed account from Navigation section

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_journal.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_journal.md
@@ -42,7 +42,6 @@ The response has no content; the response code is 204.
 
 | Navigation |Return Type| Description |
 |:----------|:----------|:-----------------|
-|[account](dynamics_account.md)|account |Gets the account of the journal.|
 |[journalLines](dynamics_journalline.md)|journalLines |Gets the journallines of the journal.|
 
 ## Properties


### PR DESCRIPTION
IMPORTANT: The suggested changes are in between the "Do not edit" section:
```
<!-- START>DO_NOT_EDIT -->
<!-- IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT. -->
<!-- IMPORTANT: END>DO_NOT_EDIT -->
```

I would assume, this needs to be change in a different repository.

---

Hello there,
it just looks like the account cannot be used.

GET `baseUrl/companies(companyId)/journals({{journalId}})/account` results in

```
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f58755e3-4518-ee11-9cc3-6045bdc89477)/journals(a7d79818-4618-ee11-9cc3-6045bdc89477)/account?tenant=default'."
    }
}
```

Could you verify this? Did I do something wrong in my requests?