### PR TITLE
Update devenv-performance-toolkit.md

### DIFF
--- a/dev-itpro/developer/devenv-performance-toolkit.md
+++ b/dev-itpro/developer/devenv-performance-toolkit.md
@@ -94,19 +94,21 @@ codeunit 50000 "Create Sales Order"
     trigger OnRun();
     var
         Customer: Record Customer;
-        *SalesHeader: Record "Sales Header";*
+        SalesHeader: Record "Sales Header";
     begin
         Customer.FindFirst();
-        *SalesHeader.Init();*
-        *SalesHeader."Document Type" := SalesHeader."Document Type"::Order;*
-        *SalesHeader.Insert(true);*
+        SalesHeader.Init();
+        SalesHeader."Document Type" := SalesHeader."Document Type"::Order;
+        SalesHeader.Insert(true);
         BCPTTestContext.EndScenario('Add Order');
         BCPTTestContext.UserWait();
         BCPTTestContext.StartScenario('Enter Account No.');
-        *SalesHeader.Validate("Sell-to Customer No.", Customer."No.");*
-        *SalesHeader.Modify(true);*
+        SalesHeader.Validate("Sell-to Customer No.", Customer."No.");
+        SalesHeader.Modify(true);
         BCPTTestContext.EndScenario('Enter Account No.');
         BCPTTestContext.UserWait();
+    end;
+}
 ```
 
 To interact with pages and make the tests more realistic, define a codeunit of the subtype **Test** and use [Test Pages](/dynamics365/business-central/dev-itpro/developer/devenv-testing-pages). The following code example shows the main difference between normal and test codeunits.
@@ -114,7 +116,7 @@ To interact with pages and make the tests more realistic, define a codeunit of t
 ```al
 codeunit 50000 "Create Sales Order"
 {
-    *Subtype = Test;*
+    Subtype = Test;
 
     var
         BCPTTestContext: Codeunit "BCPT Test Context";
@@ -122,17 +124,19 @@ codeunit 50000 "Create Sales Order"
     trigger OnRun();
     var
         Customer: Record Customer;
-        *SalesOrder: TestPage "Sales Order";*
+        SalesOrder: TestPage "Sales Order";
     begin
         Customer.FindFirst();
-        *SalesOrder.OpenNew();*
-        *SalesOrder."No.".SetValue('');*
+        SalesOrder.OpenNew();
+        SalesOrder."No.".SetValue('');
         BCPTTestContext.EndScenario('Add Order');
         BCPTTestContext.UserWait();
         BCPTTestContext.StartScenario('Enter Account No.');
-        *SalesOrder."Sell-to Customer No.".SetValue(Customer."No.");*
+        SalesOrder."Sell-to Customer No.".SetValue(Customer."No.");
         BCPTTestContext.EndScenario('Enter Account No.');
         BCPTTestContext.UserWait();
+    end;
+}
 ```
 
 > [!TIP]
@@ -187,9 +191,7 @@ enumextension 50000 "Test Codeunits with Params" extends "BCPT Test Param. Enum"
     {
         Implementation = "BCPT Test Param. Provider" = "Create PO with N Lines";
     }
-    ...
 }
-
 ```
 
 Learn more about writing test scenarios at [Testing the Application Overview](devenv-testing-application.md).


### PR DESCRIPTION
PR to update coding blocks.

- Removed the * from within the code blocks, e.g. *SalesHeader.Init();*. Is there any reason to keep them? Why not use comments to highlight these lines?

- Added to code blocks:
``` 
    end;
}
```
- Removed any empty and ... line and from code block *enumextension 50000 "Test Codeunits with Params" extends "BCPT Test Param. Enum"*