### PR TITLE
Remove wrong applyToDevExtension lines

### DIFF
--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v21.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v21.md
@@ -224,7 +224,6 @@ You'll create two versions of this extension. The first version contains the tab
       "platform": "21.0.0.0",
       "idRanges": [  ],
       "resourceExposurePolicy": {
-        "applicableToDevExtension": false,
         "allowDebugging": true,
         "allowDownloadingSource": true,
         "includeSourceInSymbolFile": true

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v22.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v22.md
@@ -224,7 +224,6 @@ You'll create two versions of this extension. The first version contains the tab
       "platform": "22.0.0.0",
       "idRanges": [  ],
       "resourceExposurePolicy": {
-        "applicableToDevExtension": false,
         "allowDebugging": true,
         "allowDownloadingSource": true,
         "includeSourceInSymbolFile": true


### PR DESCRIPTION
The keyword applicableToDevExtension does not exist. The correct name of the keyword is `applyToDevExtension`. Despite this fact, this PR removes the two lines because the default value is false already