### PR TITLE
[BC API 2.0 | companyInformation] Remove countryRegion from Navigation

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_companyinformation.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_companyinformation.md
@@ -28,13 +28,6 @@ Represents a company information in [!INCLUDE[prod_short](../../../includes/prod
 |[GET companyInformation](../api/dynamics_companyinformation_get.md)|companyInformation|Gets a company information object.|
 |[PATCH companyInformation](../api/dynamics_companyinformation_update.md)|companyInformation|Updates a company information object.|
 
-
-## Navigation
-
-| Navigation |Return Type| Description |
-|:----------|:----------|:-----------------|
-|[countryRegion](dynamics_countryregion.md)|countryRegion |Gets the countryregion of the companyInformation.|
-
 ## Properties
 
 | Property           | Type   |Description     |


### PR DESCRIPTION
I wasn't able to navigate to the specified **countryRegion** navigation.

```HTTP
GET /BC/api/v2.0/companies(f0bb10fd-583f-ee11-be74-6045bdc8c285)/companyInformation?tenant=default HTTP/1.1
Host: bcserver:7048
Authorization: Basic ***
```
