### PR TITLE
[BC API 2.0 | Get opportunity] Remove contact from Navigation

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_opportunity.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_opportunity.md
@@ -30,13 +30,6 @@ Represents an opportunity in [!INCLUDE[prod_short](../../../includes/prod_short.
 |[POST opportunity](../api/dynamics_opportunity_create.md)|opportunity|Creates a opportunity object.|
 |[PATCH opportunity](../api/dynamics_opportunity_update.md)|opportunity|Updates a opportunity object.|
 
-
-## Navigation
-
-| Navigation |Return Type| Description |
-|:----------|:----------|:-----------------|
-|[contact](dynamics_contact.md)|contact |Gets the contact of the opportunity.|
-
 ## Properties
 
 | Property           | Type   |Description     |


### PR DESCRIPTION
I'm not able to call `/contact` from an opportunity:

```HTTP
GET /BC/api/v2.0/companies(36329c99-1a21-ee11-9cc3-6045bde9b887)/opportunities(73e21668-be47-ee11-bda5-94d778321e66)/contact?tenant=default HTTP/1.1
Host: bcserver:7048
Authorization: Basic ***
```

Am I missing something?