### PR TITLE
[BC API 2.0 | purchaseReceiptLine] Remove account

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_purchaseReceiptLine.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_purchaseReceiptLine.md
@@ -33,7 +33,6 @@ Represents a purchase receipt line in [!INCLUDE[prod_short](../../../includes/pr
 | Navigation |Return Type| Description |
 |:----------|:----------|:-----------------|
 |[purchaseReceipt](dynamics_purchasereceipt.md)|purchaseReceipt |Gets the purchasereceipt of the purchaseReceiptLine.|
-|[account](dynamics_account.md)|account |Gets the account of the purchaseReceiptLine.|
 |[dimensionSetLines](dynamics_dimensionsetline.md)|dimensionSetLines |Gets the dimensionsetlines of the purchaseReceiptLine.|
 
 ## Properties


### PR DESCRIPTION
**DO NOT MERGE!** as this PR edits the lines between the **DO_NOT_EDIT** section.

When calling /account I get the following error:

```JSON
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f0bb10fd-583f-ee11-be74-6045bdc8c285)/purchaseReceipts(8de4281d-4740-ee11-ab01-d9dba4bf3ee3)/purchaseReceiptLines(77243e23-4740-ee11-ab01-d9dba4bf3ee3)/account?tenant=default'."
    }
}
```