### PR TITLE
[BC API 2.0 | salesCreditMemo] Remove countryRegion from Navigation

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_salescreditmemo.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_salescreditmemo.md
@@ -67,7 +67,6 @@ The response has no content; the response code is 204.
 | Navigation |Return Type| Description |
 |:----------|:----------|:-----------------|
 |[customer](dynamics_customer.md)|customer |Gets the customer of the salesCreditMemo.|
-|[countryRegion](dynamics_countryregion.md)|countryRegion |Gets the countryregion of the salesCreditMemo.|
 |[dimensionValue](dynamics_dimensionvalue.md)|dimensionValue |Gets the dimensionvalue of the salesCreditMemo.|
 |[currency](dynamics_currency.md)|currency |Gets the currency of the salesCreditMemo.|
 |[paymentTerm](dynamics_paymentterm.md)|paymentTerm |Gets the paymentterm of the salesCreditMemo.|


### PR DESCRIPTION
**DO NOT MERGE!** as this PR edits the lines between the **DO_NOT_EDIT** section.

When calling /countryRegion I get the following error:

```JSON
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f0bb10fd-583f-ee11-be74-6045bdc8c285)/salesCreditMemos(2ecba445-0a49-ee11-ad0b-d1b90fccd947)/countryRegion?tenant=default'."
    }
}
```