### PR TITLE
[BC API 2.0 | vendorPaymentJournal] Remove account from Navigation

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_vendorPaymentJournal.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_vendorPaymentJournal.md
@@ -35,7 +35,6 @@ Represents a vendor payment journal in [!INCLUDE[prod_short](../../../includes/p
 
 | Navigation |Return Type| Description |
 |:----------|:----------|:-----------------|
-|[account](dynamics_account.md)|account |Gets the account of the vendorPaymentJournal.|
 |[vendorPayments](dynamics_vendorpayment.md)|vendorPayments |Gets the vendorpayments of the vendorPaymentJournal.|
 
 ## Properties


### PR DESCRIPTION
**DO NOT MERGE!** as this PR edits the lines between the **DO_NOT_EDIT** section.

When calling /account I get the following error:

```JSON
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f0bb10fd-583f-ee11-be74-6045bdc8c285)/vendorPaymentJournals(5c35f239-b049-ee11-ad0b-a1422c0f7f1f)/account?tenant=default'."
    }
}
```