### PR TITLE
[BC API 2.0 | salesOrders] Remove countryRegion from Navigation

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_salesorder.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_salesorder.md
@@ -43,7 +43,6 @@ The response has no content; the response code is 204.
 | Navigation |Return Type| Description |
 |:----------|:----------|:-----------------|
 |[customer](dynamics_customer.md)|customer |Gets the customer of the salesOrder.|
-|[countryRegion](dynamics_countryregion.md)|countryRegion |Gets the countryregion of the salesOrder.|
 |[dimensionValue](dynamics_dimensionvalue.md)|dimensionValue |Gets the dimensionvalue of the salesOrder.|
 |[currency](dynamics_currency.md)|currency |Gets the currency of the salesOrder.|
 |[paymentTerm](dynamics_paymentterm.md)|paymentTerm |Gets the paymentterm of the salesOrder.|


### PR DESCRIPTION
**DO NOT MERGE!** as this PR edits the lines between the **DO_NOT_EDIT** section.

When calling /countryRegion I get the following error:

```JSON
{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f0bb10fd-583f-ee11-be74-6045bdc8c285)/salesOrders(b6f4017a-b749-ee11-ad0b-a1422c0f7f1f)/countryRegion?tenant=default'."
    }
}
```