### PR TITLE
 [BC API 2.0 | Delete salesQuoteLines] Typo

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_salesquoteline_delete.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_salesquoteline_delete.md
@@ -22,7 +22,7 @@ Delete a sales quote line object from [!INCLUDE[prod_short](../../../includes/pr
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 ```
 DELETE businesscentralPrefix/companies({id})/salesQuotes({id})/salesQuoteLines({salesQuoteLineId})
-DELETE businesscentralPrefix/companies({id})/salesQuoteLines({salesQouteLineId})
+DELETE businesscentralPrefix/companies({id})/salesQuoteLines({salesQuoteLineId})
 ```
 
 ## Request headers
@@ -45,7 +45,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://{businesscentralPrefix}/api/v2.0/companies({id})/salesQuotes({id})/salesQuoteLines({salesQouteLineId})
+DELETE https://{businesscentralPrefix}/api/v2.0/companies({id})/salesQuotes({id})/salesQuoteLines({salesQuoteLineId})
 ```
 
 **Response** 


### PR DESCRIPTION

could have combined the Create, Update and Delete salesQuoteLines *Typo* PR's into one, but I was in the zone... sorry