### PR TITLE
[BC API 2.0 | salesInvoice] Remove dimensionSetLines and countryRegion

### DIFF
--- a/dev-itpro/api-reference/v2.0/resources/dynamics_salesinvoice.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_salesinvoice.md
@@ -73,7 +73,6 @@ The response has no content; the response code is 204.
 | Navigation |Return Type| Description |
 |:----------|:----------|:-----------------|
 |[customer](dynamics_customer.md)|customer |Gets the customer of the salesInvoice.|
-|[countryRegion](dynamics_countryregion.md)|countryRegion |Gets the countryregion of the salesInvoice.|
 |[currency](dynamics_currency.md)|currency |Gets the currency of the salesInvoice.|
 |[dimensionValue](dynamics_dimensionvalue.md)|dimensionValue |Gets the dimensionvalue of the salesInvoice.|
 |[paymentTerm](dynamics_paymentterm.md)|paymentTerm |Gets the paymentterm of the salesInvoice.|
@@ -82,7 +81,6 @@ The response has no content; the response code is 204.
 |[salesInvoiceLines](dynamics_salesinvoiceline.md)|salesInvoiceLines |Gets the salesinvoicelines of the salesInvoice.|
 |[pdfDocument](dynamics_pdfdocument.md)|pdfDocument |Gets the pdfdocument of the salesInvoice.|
 |[attachments](dynamics_attachment.md)|attachments |Gets the attachments of the salesInvoice.|
-|[dimensionSetLines](dynamics_dimensionsetline.md)|dimensionSetLines |Gets the dimensionsetlines of the salesInvoice.|
 
 ## Properties
 


### PR DESCRIPTION
**DO NOT MERGE!** as this PR edits the lines between the **DO_NOT_EDIT** section.

When calling /countryRegion I get the following error:

{
    "error": {
        "code": "BadRequest_NotFound",
        "message": "No HTTP resource was found that matches the request URI 'http://bcserver:7048/BC/api/v2.0/companies(f0bb10fd-583f-ee11-be74-6045bdc8c285)/salesInvoices(d1a96836-ca49-ee11-ad0b-f362f16fe53e)/countryRegion?tenant=default'."
    }
}
```

and

and removed duplicate dimensionSetLines