### PR TITLE
Add missing UpdateKey parameter

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
@@ -33,6 +33,10 @@ An instance of the [Record](record-data-type.md) data type.
 Set this parameter to true if you want to modify any records in the set; otherwise, set the parameter to false.If you set this parameter to true, then the LOCKTABLE method (Record) is immediately run on the table before the records are read. If you set this parameter to false, then you can still modify the records in the set, but these updates will not be performed optimally. The default value is false.
           
 
+*[Optional] UpdateKey*  
+&emsp;Type: [Boolean](../boolean/boolean-data-type.md)  
+Set this parameter to true if you want to modify any field value within the current key. This parameter only applies if the ForUpdate parameter is true. If you set this parameter to false, then you can still modify the records in the set, but these updates will not be performed optimally. The default value is false.
+
 
 ## Return Value
 *[Optional] Ok*  

--- a/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
@@ -21,7 +21,7 @@ Finds a set of records in a table based on the current key and filter.
 
 ## Syntax
 ```AL
-[Ok := ]  Record.FindSet([ForUpdate: Boolean])
+[Ok := ]  Record.FindSet([ForUpdate: Boolean][, UpdateKey: Boolean])
 ```
 ## Parameters
 *Record*  


### PR DESCRIPTION
This documentation seems to be missing the `UpdateKey` argument for `FindSet`.  I grabbed the copy from the [Dynamics NAV](https://learn.microsoft.com/en-us/dynamics-nav/findset-function--record-) page for the same function hoping they are identical.  

Please let me know if you need anything else.