### PR TITLE
Align Code Style on Syntax

### DIFF
--- a/dev-itpro/developer/devenv-al-complextypes.md
+++ b/dev-itpro/developer/devenv-al-complextypes.md
@@ -25,9 +25,9 @@ The method in the example below, will take a name, and return the first customer
 /// <param name="Name">Name filter</param> 
 /// <returns>First customer</returns> 
 
-procedure GetCustomerByName(Name: Text): record Customer;
+procedure GetCustomerByName(Name: Text): Record Customer
 var
-    Customer: record Customer;
+    Customer: Record Customer;
 begin
     Customer.SetFilter(Name, '@' + Name + '*');
     Customer.FindFirst();
@@ -38,7 +38,7 @@ end;
 It's also possible to use a named return value. Internally, the exit-statement as seen in the example above causes an assignment to an allocated return value. The assignment will have a small performance cost based on the type. Since the record type is treated as a value-type, it's better.  
 
 ```al
-procedure GetCustomerByName(Name: Text) Customer: record Customer; 
+procedure GetCustomerByName(Name: Text) Customer: Record Customer
 begin 
    Customer.SetFilter(Name, '@' + Name + '*'); 
    Customer.FindFirst(); 
@@ -69,7 +69,7 @@ It doesn't only work for user-defined types like records, codeunits, etc., but a
 /// Returns a bing-ready HttpClient 
 /// </summary> 
 /// <returns>Bing HttpClient</returns> 
-procedure GetBingClient() Result: HttpClient;
+procedure GetBingClient() Result: HttpClient
 begin
     Result.SetBaseAddress('https://www.bing.com');
 end;
@@ -88,7 +88,7 @@ end;
 /// Get the response from www.bing.com as an html-string.  
 /// </summary> 
 /// <returns>string with html</returns> 
-procedure GetBingHtml() Result: Text;
+procedure GetBingHtml() Result: Text
 begin
     GetBingResponse().Content().ReadAs(Result);
 end;

--- a/dev-itpro/developer/devenv-al-control-statements.md
+++ b/dev-itpro/developer/devenv-al-control-statements.md
@@ -379,7 +379,7 @@ The *`<List>`* variable must be of the List, XmlNodeList, XmlAttributeCollection
 
 The following code example iterates through a list of customer names and returns each customer name in a message.
 ```AL  
-procedure PrintCustomerNames(customerNames : List of [Text]);
+procedure PrintCustomerNames(customerNames : List of [Text])
 var
     customerName : Text;
 begin

--- a/dev-itpro/developer/devenv-develop-for-teams-cards.md
+++ b/dev-itpro/developer/devenv-develop-for-teams-cards.md
@@ -174,7 +174,7 @@ The OnBeforeGetPageSummary event subscription has the following syntax:
 
 ```
 [EventSubscriber(ObjectType::Codeunit, Codeunit::"Page Summary Provider", 'OnBeforeGetPageSummary', '', false, false)]
-local procedure OnBeforeGetPageSummary(PageId: Integer; RecId: RecordId; var FieldsJsonArray: JsonArray; var Handled: Boolean);
+local procedure OnBeforeGetPageSummary(PageId: Integer; RecId: RecordId; var FieldsJsonArray: JsonArray; var Handled: Boolean)
 ```
 
 #### Parameters
@@ -239,7 +239,7 @@ The OnAfterGetSummaryFields event lets you add or remove from the set of fields 
 
 ```
 [EventSubscriber(ObjectType::Codeunit, Codeunit::"Page Summary Provider", 'OnAfterGetSummaryFields', '', false, false)]
-local procedure OnAfterGetSummaryFields(PageId: Integer; RecId: RecordId; var FieldList: List of [Integer]);
+local procedure OnAfterGetSummaryFields(PageId: Integer; RecId: RecordId; var FieldList: List of [Integer])
 ```
 
 #### Parameters
@@ -301,7 +301,7 @@ This event allows you to modify, add, or remove fields included in the card thro
 
 ```
 [EventSubscriber(ObjectType::Codeunit, Codeunit::"Page Summary Provider", 'OnAfterGetPageSummary', '', false, false)]
-local procedure OnAfterGetPageSummary(PageId: Integer; RecId: RecordId; var FieldsJsonArray: JsonArray);
+local procedure OnAfterGetPageSummary(PageId: Integer; RecId: RecordId; var FieldsJsonArray: JsonArray)
 ```
 
 #### Parameters

--- a/dev-itpro/developer/devenv-develop-for-teams-tab-content.md
+++ b/dev-itpro/developer/devenv-develop-for-teams-tab-content.md
@@ -71,7 +71,7 @@ codeunit 50100 UpdateRecommendedContent
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Page Action Provider", 'OnAfterGetPageActions', '', true, true)]
-    local procedure AddMyPageToRecommendedContent(PageId: Integer; IncludeViews: Boolean; var ItemsJsonArray: JsonArray);
+    local procedure AddMyPageToRecommendedContent(PageId: Integer; IncludeViews: Boolean; var ItemsJsonArray: JsonArray)
     begin
         AddRecommendedPage(ItemsJsonArray, 'My page', GetUrl(ClientType::Web, CompanyName, ObjectType::Page, Page::MyPage));
     end;

--- a/dev-itpro/developer/devenv-events-example.md
+++ b/dev-itpro/developer/devenv-events-example.md
@@ -58,7 +58,7 @@ codeunit 50101 MySubscribers
     EventSubscriberInstance = StaticAutomatic;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"MyPublishers", 'OnAddressLineChanged', '', true, true)]
-    procedure CheckAddressLine(line: Text[100]);
+    procedure CheckAddressLine(line: Text[100])
     begin
         if (STRPOS(line, '+') > 0) then begin
             MESSAGE('Can''t use a plus sign (+) in the address [' + line + ']');

--- a/dev-itpro/developer/devenv-extend-edocuments.md
+++ b/dev-itpro/developer/devenv-extend-edocuments.md
@@ -204,7 +204,7 @@ The following example shows how you can implement each method in the interface.
 - **Send:** Send an e-document to an external service.
 
     ```AL
-    procedure Send(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage);
+    procedure Send(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage)
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";
@@ -228,7 +228,7 @@ The following example shows how you can implement each method in the interface.
 - **SendBatch:** Send a batch of e-documents to an external service.
 
     ```AL
-    procedure SendBatch(var EDocuments: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage);
+    procedure SendBatch(var EDocuments: Record "E-Document"; var TempBlob: Codeunit "Temp Blob"; var IsAsync: Boolean; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage)
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";
@@ -252,7 +252,7 @@ The following example shows how you can implement each method in the interface.
 - **GetResponse:** Get the response of an asynchronous send request.
 
     ```AL
-    procedure GetResponse(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean;
+    procedure GetResponse(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";
@@ -273,7 +273,7 @@ The following example shows how you can implement each method in the interface.
 - **GetApproval:** Check whether a document is approved or rejected.
 
     ```AL
-    procedure GetResponse(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean;
+    procedure GetResponse(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";
@@ -294,7 +294,7 @@ The following example shows how you can implement each method in the interface.
 - **GetApproval:** Check whether a document is approved or rejected.
 
     ```AL
-    procedure GetApproval(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean;
+    procedure GetApproval(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";
@@ -315,7 +315,7 @@ The following example shows how you can implement each method in the interface.
 - **Cancel:** Send a cancel request for an e-document.
 
     ```AL
-    procedure Cancel(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean;
+    procedure Cancel(var EDocument: Record "E-Document"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";
@@ -336,7 +336,7 @@ The following example shows how you can implement each method in the interface.
 - **ReceiveDocument:** Receive an e-document from an external service.
 
     ```AL
-    procedure ReceiveDocument(var TempBlob: Codeunit "Temp Blob"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage);
+    procedure ReceiveDocument(var TempBlob: Codeunit "Temp Blob"; var HttpRequest: HttpRequestMessage; var HttpResponse: HttpResponseMessage)
     var
         // Record that hold integration setup
         ExampleIntegration: Record "Example - Test Integration";

--- a/dev-itpro/developer/devenv-extending-best-price-calculations.md
+++ b/dev-itpro/developer/devenv-extending-best-price-calculations.md
@@ -147,7 +147,7 @@ Now we'll subscribe to the 'OnCopyFromSalesPrice' event to copy data from "Sales
 codeunit 50012 "Copy DocumentNo to Price List"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::CopyFromToPriceListLine, 'OnCopyFromSalesPrice', '', false, false)]
-    procedure CopyFromSalesPriceHandler(var SalesPrice: Record "Sales Price"; var PriceListLine: Record "Price List Line");
+    procedure CopyFromSalesPriceHandler(var SalesPrice: Record "Sales Price"; var PriceListLine: Record "Price List Line")
     begin
         PriceListLine."Document No." := SalesPrice."Document No.";
     end;
@@ -421,13 +421,13 @@ The calculation that links these three new fields is based on the following even
 codeunit 50004 "Attached Price Mgt."
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Price Calculation Buffer Mgt.", 'OnAfterSetFilters', '', false, false)]
-    procedure OnAfterSetFilters(var PriceListLine: Record "Price List Line"; AmountType: Enum "Price Amount Type"; var PriceCalculationBuffer: Record "Price Calculation Buffer"; ShowAll: Boolean);
+    procedure OnAfterSetFilters(var PriceListLine: Record "Price List Line"; AmountType: Enum "Price Amount Type"; var PriceCalculationBuffer: Record "Price Calculation Buffer"; ShowAll: Boolean)
     begin
         PriceListLine.SetRange("Attach To Item No.", PriceCalculationBuffer."Attach To Item No.");
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Line - Price", 'OnAfterFillBuffer', '', false, false)]
-    procedure OnAfterFillBuffer(var PriceCalculationBuffer: Record "Price Calculation Buffer"; SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line");
+    procedure OnAfterFillBuffer(var PriceCalculationBuffer: Record "Price Calculation Buffer"; SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line")
     begin
         PriceCalculationBuffer."Attach To Item No." := FindItemToAttachToInLine(SalesLine);
     end;
@@ -571,7 +571,7 @@ The following codeunit shows a sample implementation.
 codeunit 50001 "Fixed Asset Price Calc."
 {
     [EventSubscriber(ObjectType::Table, Database::"Sales Line", 'OnBeforeUpdateUnitPrice', '', false, false)]
-    local procedure OnBeforeUpdateUnitPrice(var SalesLine: Record "Sales Line"; xSalesLine: Record "Sales Line"; CalledByFieldNo: Integer; CurrFieldNo: Integer; var Handled: Boolean);
+    local procedure OnBeforeUpdateUnitPrice(var SalesLine: Record "Sales Line"; xSalesLine: Record "Sales Line"; CalledByFieldNo: Integer; CurrFieldNo: Integer; var Handled: Boolean)
     begin
         if SalesLine.Type = SalesLine.Type::"Fixed Asset" then begin
             UpdateUnitPriceByField(SalesLine, xSalesLine, CalledByFieldNo, CurrFieldNo);
@@ -580,7 +580,7 @@ codeunit 50001 "Fixed Asset Price Calc."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Line - Price", 'OnAfterGetAssetType', '', false, false)]
-    local procedure OnAfterGetAssetType(SalesLine: Record "Sales Line"; var AssetType: Enum "Price Asset Type");
+    local procedure OnAfterGetAssetType(SalesLine: Record "Sales Line"; var AssetType: Enum "Price Asset Type")
     begin
         if SalesLine.Type = SalesLine.Type::"Fixed Asset" then
             AssetType := AssetType::"Fixed Asset";
@@ -721,7 +721,7 @@ The following example shows how.
 codeunit 50004 "Location Source Price Calc."
 {
     [EventSubscriber(ObjectType::Table, Database::"Sales Line", 'OnValidateLocationCodeOnAfterSetOutboundWhseHandlingTime', '', false, false)]
-    local procedure OnValidateLocationCodeOnAfterSetOutboundWhseHandlingTime(var SalesLine: Record "Sales Line");
+    local procedure OnValidateLocationCodeOnAfterSetOutboundWhseHandlingTime(var SalesLine: Record "Sales Line")
     begin
         UpdateUnitPriceByLocationCode(SalesLine);
     end;
@@ -800,7 +800,7 @@ codeunit 50005 "Hierarchical Price Calc."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Price Calculation Mgt.", 'OnFindSupportedSetup', '', false, false)]
-    local procedure OnFindSupportedSetup(var TempPriceCalculationSetup: Record "Price Calculation Setup");
+    local procedure OnFindSupportedSetup(var TempPriceCalculationSetup: Record "Price Calculation Setup")
     begin
         TempPriceCalculationSetup.Init();
         TempPriceCalculationSetup.Method := TempPriceCalculationSetup.Method::Hierarchical;
@@ -813,7 +813,7 @@ codeunit 50005 "Hierarchical Price Calc."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Line - Price", 'OnAfterAddSources', '', false, false)]
-    local procedure OnAfterAddSources(SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line"; PriceType: Enum "Price Type"; var PriceSourceList: Codeunit "Price Source List");
+    local procedure OnAfterAddSources(SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line"; PriceType: Enum "Price Type"; var PriceSourceList: Codeunit "Price Source List")
     begin
         if SalesLine."Price Calculation Method" = "Price Calculation Method"::Hierarchical then
             SetHierarchicalSourceList(SalesHeader, SalesLine, PriceSourceList);

--- a/dev-itpro/developer/devenv-extending-best-price-calculations.md
+++ b/dev-itpro/developer/devenv-extending-best-price-calculations.md
@@ -1,5 +1,6 @@
 ---
 title: "Extending Price Calculations"
+description: "How you extend the price calculations in Dynamics 365 Business Central."
 ms.custom: na
 ms.date: 04/01/2021
 ms.reviewer: na

--- a/dev-itpro/developer/devenv-extending-item-charges.md
+++ b/dev-itpro/developer/devenv-extending-item-charges.md
@@ -73,7 +73,7 @@ codeunit 50100 "Item Ch. Assign by Fairy Dust"
 In the new codeunit, add functions to distribute the charges over the item lines.
 
 ```AL
-    local procedure AssignByFairyDust(var ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)"; Currency: Record Currency; TotalQtyToAssign: Decimal; TotalAmtToAssign: Decimal);
+    local procedure AssignByFairyDust(var ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)"; Currency: Record Currency; TotalQtyToAssign: Decimal; TotalAmtToAssign: Decimal)
     var
         TempItemChargeAssgntPurch: Record "Item Charge Assignment (Purch)" temporary;
         LineArray: array[2] OF Decimal;
@@ -122,7 +122,7 @@ In the new codeunit, add functions to distribute the charges over the item lines
         TempItemChargeAssgntPurch.DeleteAll(false);
     end;
 
-    procedure GetItemValues(TempItemChargeAssgntPurch: Record "Item Charge Assignment (Purch)" temporary; var DecimalArray: Array[2] OF Decimal);
+    procedure GetItemValues(TempItemChargeAssgntPurch: Record "Item Charge Assignment (Purch)" temporary; var DecimalArray: Array[2] of Decimal)
     var
         PurchaseLine: Record "Purchase Line";
         PurchRcptLine: Record "Purch. Rcpt. Line";
@@ -184,7 +184,7 @@ In the new codeunit, add a subscriber to the **OnAssignItemCharges** event.
 
 ```AL
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Item Charge Assgnt. (Purch.)", 'OnAssignItemCharges', '', false, false)]
-    local procedure AssignByFairyDustOnAssignItemCharges(SelectionTxt: Text; var ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)"; Currency: Record Currency; PurchaseHeader: Record "Purchase Header"; TotalQtyToAssign: Decimal; TotalAmtToAssign: Decimal; VAR ItemChargesAssigned: Boolean);
+    local procedure AssignByFairyDustOnAssignItemCharges(SelectionTxt: Text; var ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)"; Currency: Record Currency; PurchaseHeader: Record "Purchase Header"; TotalQtyToAssign: Decimal; TotalAmtToAssign: Decimal; var ItemChargesAssigned: Boolean)
     begin
         // if item charges are already assigned, exit
         if ItemChargesAssigned then

--- a/dev-itpro/developer/devenv-extending-shopify.md
+++ b/dev-itpro/developer/devenv-extending-shopify.md
@@ -469,7 +469,7 @@ The following example shows how to use the GTIN field to map imported products t
 codeunit 50108 "Shpfy Product Import Mapping"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Product Events", 'OnBeforeFindMapping', '', false, false)]
-    procedure BeforeFindMapping(Direction: enum "Shpfy Mapping Direction"; var ShopifyProduct: Record "Shpfy Product"; var ShopifyVariant: Record "Shpfy Variant"; var Item: Record Item; ItemVariant: Record "Item Variant"; var Handled: Boolean);
+    procedure BeforeFindMapping(Direction: Enum "Shpfy Mapping Direction"; var ShopifyProduct: Record "Shpfy Product"; var ShopifyVariant: Record "Shpfy Variant"; var Item: Record Item; ItemVariant: Record "Item Variant"; var Handled: Boolean)
     var
         FindItem: Record Item;
     begin

--- a/dev-itpro/developer/devenv-extension-example.md
+++ b/dev-itpro/developer/devenv-extension-example.md
@@ -448,7 +448,7 @@ codeunit 50105 RewardsInstallCode
     end;
 
     // Insert the GOLD, SILVER, BRONZE reward levels
-    procedure InsertDefaultRewards();
+    procedure InsertDefaultRewards()
     begin
         InsertRewardLevel('GOLD', 'Gold Level', 20);
         InsertRewardLevel('SILVER', 'Silver Level', 10);
@@ -456,7 +456,7 @@ codeunit 50105 RewardsInstallCode
     end;
 
     // Create and insert a reward level in the "Reward" table.
-    procedure InsertRewardLevel(ID : Code[30]; Description : Text[250]; Discount : Decimal);
+    procedure InsertRewardLevel(ID : Code[30]; Description : Text[250]; Discount : Decimal)
     var
         Reward : Record Reward;
     begin

--- a/dev-itpro/developer/devenv-extension-install-code.md
+++ b/dev-itpro/developer/devenv-extension-install-code.md
@@ -84,7 +84,7 @@ codeunit 50100 MyInstallCodeunit
             HandleReinstall;
     end;
 
-    local procedure HandleFreshInstall();
+    local procedure HandleFreshInstall()
     begin
         // Do work needed the first time this extension is ever installed for this tenant.
         // Some possible usages:
@@ -92,7 +92,7 @@ codeunit 50100 MyInstallCodeunit
         // - Initial data setup for use
     end;
 
-    local procedure HandleReinstall();
+    local procedure HandleReinstall()
     begin
         // Do work needed when reinstalling the same version of this extension back on this tenant.
         // Some possible usages:

--- a/dev-itpro/developer/devenv-onafterdocumentprintready-event.md
+++ b/dev-itpro/developer/devenv-onafterdocumentprintready-event.md
@@ -29,7 +29,7 @@ When a user selects the print action on a report request page
 
 ```AL
 IntegrationEvent(false, false)]
-local procedure OnAfterDocumentPrintReady(ObjectType: Option "Report","Page"; ObjectId: Integer; ObjectPayload: JsonObject; DocumentStream: InStream; var Success: Boolean);
+local procedure OnAfterDocumentPrintReady(ObjectType: Option "Report","Page"; ObjectId: Integer; ObjectPayload: JsonObject; DocumentStream: InStream; var Success: Boolean)
 ```
 
 ## Parameters

--- a/dev-itpro/developer/devenv-table-object.md
+++ b/dev-itpro/developer/devenv-table-object.md
@@ -94,7 +94,7 @@ table 50104 Address
 
     end;
 
-    procedure MyMethod();
+    procedure MyMethod()
     begin
         Message(Msg);
     end;


### PR DESCRIPTION
- Remove semicolon at end of procedures
- Fix Casing on keywords like `Enum`, `Record`, `var`
- 