### PR TITLE
Added Digest Authentication deprecation

### DIFF
--- a/dev-itpro/developer/includes/include-odata-username-auth.md
+++ b/dev-itpro/developer/includes/include-odata-username-auth.md
@@ -1,1 +1,1 @@
-For OData, **UserName** credential type is only supported in Business Central version 20 and earlier. In later versions, change to [NavUserPassword](../../administration/authenticating-users-with-navuserpassword.md) instead. 
+For OData, **UserName** credential type is only supported in Business Central version 20 and earlier. In later versions, change to [NavUserPassword](../../administration/authenticating-users-with-navuserpassword.md) instead. This implies deprecation of native Digest Authentication from version 21 onwards.   


### PR DESCRIPTION
Removing UserName from OData, automatically removes the capability of having Digest Authentication in web services. This is also discussed and confirmed in the following Viva Engage (formerly Yammer) thread https://www.yammer.com/dynamicsnavdev/threads/2281376317923328