### PR TITLE
recordref with scope

### DIFF
--- a/dev-itpro/developer/methods-auto/recordref/recordref-data-type.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-data-type.md
@@ -110,7 +110,7 @@ The following methods are available on instances of the RecordRef data type.
 
 ## Remarks 
  
-The RecordRef object can refer to any table in the database if the extension target in [app.json](../../devenv-json-files#appjson-file) doesn't conflict with the field/table [scope](../../attributes/devenv-scope-attribute.md). Example, an extension with target Cloud can't use RecordRef to access a table with scope OnPrem.
+The RecordRef object can refer to any table in the database if the extension target in [app.json](../../devenv-json-files.md#appjson-file) doesn't conflict with the field/table [scope](../../attributes/devenv-scope-attribute.md). Example, an extension with target Cloud can't use RecordRef to access a table with scope OnPrem.
 Use the [Open method](recordref-open-method.md) to use the table number to select the table that you want to access, or use the [GetTable method](recordref-gettable-method.md) to use another record variable to select the table that you want to access.  
   
 If one RecordRef variable is assigned to another RecordRef variable, then they both refer to the same table instance. 

--- a/dev-itpro/developer/methods-auto/recordref/recordref-data-type.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-data-type.md
@@ -3,7 +3,7 @@ title: "RecordRef Data Type"
 description: "References a record in a table."
 ms.author: solsen
 ms.custom: na
-ms.date: 12/01/2023
+ms.date: 01/11/2024
 ms.reviewer: na
 ms.suite: na
 ms.tgt_pltfrm: na
@@ -110,11 +110,11 @@ The following methods are available on instances of the RecordRef data type.
 
 ## Remarks 
  
-The RecordRef object can refer to any table in the database if the extension target in [app.json](../../devenv-json-files.md#appjson-file) doesn't conflict with the field/table [scope](../../attributes/devenv-scope-attribute.md). Example, an extension with target Cloud can't use RecordRef to access a table with scope OnPrem.
+The `RecordRef` object can refer to any table in the database, if the extension target in [app.json](../../devenv-json-files.md#appjson-file) doesn't conflict with the field/table [scope](../../attributes/devenv-scope-attribute.md). Example, an extension with target `Cloud` can't use `RecordRef` to access a table with scope `OnPrem`.
 Use the [Open method](recordref-open-method.md) to use the table number to select the table that you want to access, or use the [GetTable method](recordref-gettable-method.md) to use another record variable to select the table that you want to access.  
   
-If one RecordRef variable is assigned to another RecordRef variable, then they both refer to the same table instance. 
+If one `RecordRef` variable is assigned to another `RecordRef` variable, then they both refer to the same table instance. 
 
-## See Also  
-[Get Started with AL](../../devenv-get-started.md)  
-[Developing Extensions](../../devenv-dev-overview.md)  
+## See also  
+[Get started with AL](../../devenv-get-started.md)  
+[Developing extensions](../../devenv-dev-overview.md)  

--- a/dev-itpro/developer/methods-auto/recordref/recordref-data-type.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-data-type.md
@@ -110,7 +110,8 @@ The following methods are available on instances of the RecordRef data type.
 
 ## Remarks 
  
-The RecordRef object can refer to any table in the database. Use the [Open method](recordref-open-method.md) to use the table number to select the table that you want to access, or use the [GetTable method](recordref-gettable-method.md) to use another record variable to select the table that you want to access.  
+The RecordRef object can refer to any table in the database if the extension target in [app.json](../../devenv-json-files#appjson-file) doesn't conflict with the field/table [scope](../../attributes/devenv-scope-attribute.md). Example, an extension with target Cloud can't use RecordRef to access a table with scope OnPrem.
+Use the [Open method](recordref-open-method.md) to use the table number to select the table that you want to access, or use the [GetTable method](recordref-gettable-method.md) to use another record variable to select the table that you want to access.  
   
 If one RecordRef variable is assigned to another RecordRef variable, then they both refer to the same table instance. 
 


### PR DESCRIPTION
I want to update this because I noticed that I couldn't reach a system table with scope onprem and the extensin had target cloud.

![image](https://github.com/MicrosoftDocs/dynamics365smb-devitpro-pb/assets/34970096/afff49b9-73aa-41cc-b048-9fa6da4e6e3c)
`recref.Open(2000000121); //user Property`
![image](https://github.com/MicrosoftDocs/dynamics365smb-devitpro-pb/assets/34970096/29005958-5ffe-4334-9177-95315db79e53)


But it worked for another system table without scope
`recref.Open(2000000078); //chart`
![image](https://github.com/MicrosoftDocs/dynamics365smb-devitpro-pb/assets/34970096/99b7c36c-81f1-4eac-8801-3217267e88ba)

This is tested on: Version: SE Business Central 23.2 (Platform 23.0.14532.0 + Application 23.2.14098.14562)
