### PR TITLE
Reminder for in-page jumped readers

### DIFF
--- a/dev-itpro/administration/telemetry-database-locks-trace.md
+++ b/dev-itpro/administration/telemetry-database-locks-trace.md
@@ -70,6 +70,8 @@ Occurs when a database lock has timed out for a session.
 ### Sample KQL code
 
 This KQL code can help you get started troubleshooting lock timeouts.
+> [!NOTE]
+> Reminder, as stated in [previous section](#analyzing-database-lock-timeout-trace-telemetry) that if these events can't be found on on-premise installations it is because the `EnableLockTimeoutMonitoring` setting is inactivated.
 
 ```kql
 traces 


### PR DESCRIPTION
I have had several occasions where I start from page[ Telemetry Events](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/telemetry-event-ids),  click a link to the event and then I get to a section that is in the "middle of the page".  The problem is that I don't notice/expect that I have landed on middle of the page and thus miss important information.

![image](https://github.com/MicrosoftDocs/dynamics365smb-devitpro-pb/assets/34970096/06fc3d15-b89c-403a-958c-d63fc33da077)

I have at multiple occasions thought of writing on yaml to ask why I don't see this event. Yesterday I realised that the information was on the same page and then was after some googling trying to find out why the event was not thrown. 