### PR TITLE
Added Note for Inherent Permissions

### DIFF
--- a/dev-itpro/developer/attributes/devenv-inherentpermissions-attribute.md
+++ b/dev-itpro/developer/attributes/devenv-inherentpermissions-attribute.md
@@ -58,6 +58,9 @@ Specifies the scope of the permissions that are assigned (Entitlements, Permissi
 > [!NOTE]  
 > Specifying `InherentPermissionsScope` is optional and the default is *Both* that includes permissions and entitlements. To read about different types of scope, see [InherentPermissionsScope Option](../methods-auto/inherentpermissionsscope/inherentpermissionsscope-option.md).
 
+> [!NOTE]
+> You can use inherent permissions only for objects within the same extension.
+
 ## See Also  
 [Get Started with AL](../devenv-get-started.md)  
 [Developing Extensions](../devenv-dev-overview.md)  

--- a/dev-itpro/developer/methods-auto/inherentpermissionsscope/inherentpermissionsscope-option.md
+++ b/dev-itpro/developer/methods-auto/inherentpermissionsscope/inherentpermissionsscope-option.md
@@ -27,7 +27,10 @@ The different types of scope that the InherentPermissions attribute can apply to
 
 ## Remarks
 
-*InherentPermissionScope* is used as a parameter with InherentPermissions attribute, which can override the entitlements. It's an optional method and the default value for InherentPermissionScope is *Both* that includes permissions and entitlements. To learn more about syntax and usage of InherentPermissions attribute, see [InherentPermissions Attribute](../../attributes/devenv-inherentpermissions-attribute.md). 
+*InherentPermissionScope* is used as a parameter with InherentPermissions attribute, which can override the entitlements. It's an optional method and the default value for InherentPermissionScope is *Both* that includes permissions and entitlements. To learn more about syntax and usage of InherentPermissions attribute, see [InherentPermissions Attribute](../../attributes/devenv-inherentpermissions-attribute.md).
+
+> [!NOTE]
+> You can use inherent permissions only for objects within the same extension.
 
 ## Example
 


### PR DESCRIPTION
I added the important note for the Inheren Permissions Property to more documentation pages since it's very important to know that this property can only be used for tables of the own extension.