### PR TITLE
Fix multipart form example for binary file uploads

### DIFF
--- a/dev-itpro/developer/methods-auto/httpclient/httpclient-post-method.md
+++ b/dev-itpro/developer/methods-auto/httpclient/httpclient-post-method.md
@@ -183,7 +183,7 @@ The main reason for the code example being different when dealing with binary da
         Headers: HttpHeaders;
         Response: HttpResponseMessage;
         MultiPartBody: TextBuilder;
-        MultiPartBodyOutStream: : OutStream;
+        MultiPartBodyOutStream: OutStream;
         MultiPartBodyInStream: InStream;
         TempBlob: Record TempBlob temporary;
         Boundary: Text;
@@ -205,6 +205,7 @@ The main reason for the code example being different when dealing with binary da
         CopyStream(MultiPartBodyOutStream, ContentToBeUploaded);
 
         MultiPartBody.Clear();
+        MultiPartBody.AppendLine();
         MultiPartBody.AppendLine('--' + Format(Boundary) + '--');
         MultiPartBodyOutStream.WriteText(MultiPartBody.ToText());
 


### PR DESCRIPTION
The last encapsulation boundary must also be preceded with a CRLF, as per RFC1341 https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html. 

Incidentally, the example did work if the `InStream` `ContentToBeUploaded` ends with a CRLF, but the server essentially then receives a file that has its last CRLF trimmed, which is not correct. 

For raw binary files that do not end with CRLF themselves (most do not of course), our server actually responded with a status code `100 Continue` indicating it did not 'see' the terminating boundary but instead considered it part of the body and was waiting for more data in the next chunked request.

Additionally, fixed a small typo in the variables.