### PR TITLE
[BC API 2.0] Update purchaseCreditMemos and purchaseCreditMemoLines

### DIFF
--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_create.md
@@ -1,5 +1,5 @@
 ---
-title: Create purchaseCreditMemoes
+title: Create purchaseCreditMemos
 description: Creates a purchase credit memo object in Dynamics 365 Business Central.
 author: SusanneWindfeldPedersen
 ms.service: dynamics-365-business-central
@@ -13,7 +13,7 @@ ms.author: solsen
 
 <!-- NOTE: This article is an auto-generated stub from the metadata file. -->
 <!-- The sections marked with an EDIT_IS_REQUIRED require manual editing. -->
-# Create purchaseCreditMemoes
+# Create purchaseCreditMemos
 
 Creates a purchase credit memo in [!INCLUDE[prod_short](../../../includes/prod_short.md)].
 
@@ -22,7 +22,7 @@ Creates a purchase credit memo in [!INCLUDE[prod_short](../../../includes/prod_s
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different or there might be more than one -->
 ```
-POST businesscentralPrefix/companies({id})/purchaseCreditMemoes({id})
+POST businesscentralPrefix/companies({id})/purchaseCreditMemos({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 ## Request headers
@@ -49,50 +49,39 @@ If successful, this method returns ```201 Created``` response code and a **purch
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different. Fill in the property values -->
 ```json
-POST https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoes({id})
+POST https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})
 Content-type: application/json
 {
-    "id" : "",
-    "number" : "",
-    "creditMemoDate" : "",
-    "postingDate" : "",
-    "dueDate" : "",
-    "vendorId" : "",
-    "vendorNumber" : "",
-    "vendorName" : "",
-    "payToVendorId" : "",
-    "payToVendorNumber" : "",
-    "payToName" : "",
-    "buyFromAddressLine1" : "",
-    "buyFromAddressLine2" : "",
-    "buyFromCity" : "",
-    "buyFromCountry" : "",
-    "buyFromState" : "",
-    "buyFromPostCode" : "",
-    "payToAddressLine1" : "",
-    "payToAddressLine2" : "",
-    "payToCity" : "",
-    "payToCountry" : "",
-    "payToState" : "",
-    "payToPostCode" : "",
-    "shortcutDimension1Code" : "",
-    "shortcutDimension2Code" : "",
-    "currencyId" : "",
-    "currencyCode" : "",
-    "paymentTermsId" : "",
-    "shipmentMethodId" : "",
-    "purchaser" : "",
-    "pricesIncludeTax" : "",
-    "discountAmount" : "",
-    "discountAppliedBeforeTax" : "",
-    "totalAmountExcludingTax" : "",
-    "totalTaxAmount" : "",
-    "totalAmountIncludingTax" : "",
-    "status" : "",
-    "lastModifiedDateTime" : "",
-    "invoiceId" : "",
-    "invoiceNumber" : "",
-    "vendorReturnReasonId" : ""
+    "creditMemoDate": "2024-01-08",
+    "postingDate": "2024-01-08",
+    "dueDate": "2024-01-08",
+    "vendorId": "60748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "vendorNumber": "20000",
+    "payToVendorId": "60748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "payToVendorNumber": "20000",
+    "buyFromAddressLine1": "100 Day Drive",
+    "buyFromAddressLine2": "",
+    "buyFromCity": "Chicago",
+    "buyFromCountry": "US",
+    "buyFromState": "IL",
+    "buyFromPostCode": "61236",
+    "payToAddressLine1": "100 Day Drive",
+    "payToAddressLine2": "",
+    "payToCity": "Chicago",
+    "payToCountry": "US",
+    "payToState": "IL",
+    "payToPostCode": "61236",
+    "shortcutDimension1Code": "",
+    "shortcutDimension2Code": "",
+    "currencyId": "00000000-0000-0000-0000-000000000000",
+    "currencyCode": "USD",
+    "paymentTermsId": "62728e9f-8401-ef11-9f8f-6045bde9b6de",
+    "shipmentMethodId": "00000000-0000-0000-0000-000000000000",
+    "purchaser": "",
+    "discountAmount": 0,
+    "invoiceId": "00000000-0000-0000-0000-000000000000",
+    "invoiceNumber": "",
+    "vendorReturnReasonId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->
@@ -104,47 +93,47 @@ Here is an example of the response.
 HTTP/1.1 201 Created
 Content-type: application/json
 {
-    "id" : "",
-    "number" : "",
-    "creditMemoDate" : "",
-    "postingDate" : "",
-    "dueDate" : "",
-    "vendorId" : "",
-    "vendorNumber" : "",
-    "vendorName" : "",
-    "payToVendorId" : "",
-    "payToVendorNumber" : "",
-    "payToName" : "",
-    "buyFromAddressLine1" : "",
-    "buyFromAddressLine2" : "",
-    "buyFromCity" : "",
-    "buyFromCountry" : "",
-    "buyFromState" : "",
-    "buyFromPostCode" : "",
-    "payToAddressLine1" : "",
-    "payToAddressLine2" : "",
-    "payToCity" : "",
-    "payToCountry" : "",
-    "payToState" : "",
-    "payToPostCode" : "",
-    "shortcutDimension1Code" : "",
-    "shortcutDimension2Code" : "",
-    "currencyId" : "",
-    "currencyCode" : "",
-    "paymentTermsId" : "",
-    "shipmentMethodId" : "",
-    "purchaser" : "",
-    "pricesIncludeTax" : "",
-    "discountAmount" : "",
-    "discountAppliedBeforeTax" : "",
-    "totalAmountExcludingTax" : "",
-    "totalTaxAmount" : "",
-    "totalAmountIncludingTax" : "",
-    "status" : "",
-    "lastModifiedDateTime" : "",
-    "invoiceId" : "",
-    "invoiceNumber" : "",
-    "vendorReturnReasonId" : ""
+    "id": "b5fcbb14-7402-ef11-b3c3-83fe9ccecec3",
+    "number": "1004",
+    "creditMemoDate": "2024-01-08",
+    "postingDate": "2024-01-08",
+    "dueDate": "2024-01-08",
+    "vendorId": "60748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "vendorNumber": "20000",
+    "vendorName": "First Up Consultants",
+    "payToVendorId": "60748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "payToVendorNumber": "20000",
+    "payToName": "First Up Consultants",
+    "buyFromAddressLine1": "100 Day Drive",
+    "buyFromAddressLine2": "",
+    "buyFromCity": "Chicago",
+    "buyFromCountry": "US",
+    "buyFromState": "IL",
+    "buyFromPostCode": "61236",
+    "payToAddressLine1": "100 Day Drive",
+    "payToAddressLine2": "",
+    "payToCity": "Chicago",
+    "payToCountry": "US",
+    "payToState": "IL",
+    "payToPostCode": "61236",
+    "shortcutDimension1Code": "",
+    "shortcutDimension2Code": "",
+    "currencyId": "00000000-0000-0000-0000-000000000000",
+    "currencyCode": "USD",
+    "paymentTermsId": "62728e9f-8401-ef11-9f8f-6045bde9b6de",
+    "shipmentMethodId": "00000000-0000-0000-0000-000000000000",
+    "purchaser": "",
+    "pricesIncludeTax": false,
+    "discountAmount": 0,
+    "discountAppliedBeforeTax": false,
+    "totalAmountExcludingTax": 0,
+    "totalTaxAmount": 0,
+    "totalAmountIncludingTax": 0,
+    "status": "Draft",
+    "lastModifiedDateTime": "2024-04-24T19:51:46.917Z",
+    "invoiceId": "00000000-0000-0000-0000-000000000000",
+    "invoiceNumber": "",
+    "vendorReturnReasonId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_delete.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_delete.md
@@ -1,5 +1,5 @@
 ---
-title: Delete purchaseCreditMemoes
+title: Delete purchaseCreditMemos
 description: Deletes a purchase credit memo object in Dynamics 365 Business Central.
 author: SusanneWindfeldPedersen
 ms.service: dynamics-365-business-central
@@ -13,7 +13,7 @@ ms.author: solsen
 
 <!-- NOTE: This article is an auto-generated stub from the metadata file. -->
 <!-- The sections marked with an EDIT_IS_REQUIRED require manual editing. -->
-# Delete purchaseCreditMemoes
+# Delete purchaseCreditMemos
 
 Deletes a purchase credit memo from [!INCLUDE[prod_short](../../../includes/prod_short.md)].
 
@@ -22,7 +22,7 @@ Deletes a purchase credit memo from [!INCLUDE[prod_short](../../../includes/prod
 Replaces the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different or there might be more than one -->
 ```
-DELETE businesscentralPrefix/companies({id})/purchaseCreditMemoes({id})
+DELETE businesscentralPrefix/companies({id})/purchaseCreditMemos({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 ## Request headers
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code and delete
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different -->
 ```json
-DELETE https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoes({id})
+DELETE https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 **Response**

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_get.md
@@ -1,5 +1,5 @@
 ---
-title: Get purchaseCreditMemoes
+title: Get purchaseCreditMemos
 description: Gets a purchase credit memo object in Dynamics 365 Business Central.
 author: SusanneWindfeldPedersen
 ms.service: dynamics-365-business-central
@@ -13,7 +13,7 @@ ms.author: solsen
 
 <!-- NOTE: This article is an auto-generated stub from the metadata file. -->
 <!-- The sections marked with an EDIT_IS_REQUIRED require manual editing. -->
-# Get purchaseCreditMemoes
+# Get purchaseCreditMemos
 
 Retrieves the properties and relationships of a purchase credit memo object for [!INCLUDE[prod_short](../../../includes/prod_short.md)].
 
@@ -22,7 +22,7 @@ Retrieves the properties and relationships of a purchase credit memo object for 
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different -->
 ```
-GET businesscentralPrefix/companies({id})/purchaseCreditMemoes({id})
+GET businesscentralPrefix/companies({id})/purchaseCreditMemos({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 ## Request headers
@@ -46,7 +46,7 @@ If successful, this method returns a ```200 OK``` response code and a **purchase
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different -->
 ```json
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoes({id})
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 **Response**

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_update.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemo_update.md
@@ -1,5 +1,5 @@
 ---
-title: Update purchaseCreditMemoes
+title: Update purchaseCreditMemos
 description: Updates a  purchase credit memo object in Dynamics 365 Business Central.
 author: SusanneWindfeldPedersen
 ms.service: dynamics-365-business-central
@@ -13,7 +13,7 @@ ms.author: solsen
 
 <!-- NOTE: This article is an auto-generated stub from the metadata file. -->
 <!-- The sections marked with an EDIT_IS_REQUIRED require manual editing. -->
-# Update purchaseCreditMemoes
+# Update purchaseCreditMemos
 
 Updates the properties of a purchase credit memo object for [!INCLUDE[prod_short](../../../includes/prod_short.md)].
 
@@ -22,7 +22,7 @@ Updates the properties of a purchase credit memo object for [!INCLUDE[prod_short
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different or there might be more than one-->
 ```
-PATCH businesscentralPrefix/companies({id})/purchaseCreditMemoes({id})
+PATCH businesscentralPrefix/companies({id})/purchaseCreditMemos({id})
 ```
 <!-- END>EDIT_IS_REQUIRED-->
 ## Request headers
@@ -48,11 +48,10 @@ If successful, this method returns a ```200 OK``` response code and an updated *
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different. Fill in the property values) -->
 ```json
-PATCH https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoes({id})
+PATCH https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})
 Content-type: application/json
 {
-    "id" : ,
-    "number" :
+    "dueDate": "2022-02-10"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->
@@ -65,47 +64,47 @@ Here is an example of the response.
 HTTP/1.1 200 OK
 Content-type: application/json
 {
-    "id" : ,
-    "number" : ,
-    "creditMemoDate" : ,
-    "postingDate" : ,
-    "dueDate" : ,
-    "vendorId" : ,
-    "vendorNumber" : ,
-    "vendorName" : ,
-    "payToVendorId" : ,
-    "payToVendorNumber" : ,
-    "payToName" : ,
-    "buyFromAddressLine1" : ,
-    "buyFromAddressLine2" : ,
-    "buyFromCity" : ,
-    "buyFromCountry" : ,
-    "buyFromState" : ,
-    "buyFromPostCode" : ,
-    "payToAddressLine1" : ,
-    "payToAddressLine2" : ,
-    "payToCity" : ,
-    "payToCountry" : ,
-    "payToState" : ,
-    "payToPostCode" : ,
-    "shortcutDimension1Code" : ,
-    "shortcutDimension2Code" : ,
-    "currencyId" : ,
-    "currencyCode" : ,
-    "paymentTermsId" : ,
-    "shipmentMethodId" : ,
-    "purchaser" : ,
-    "pricesIncludeTax" : ,
-    "discountAmount" : ,
-    "discountAppliedBeforeTax" : ,
-    "totalAmountExcludingTax" : ,
-    "totalTaxAmount" : ,
-    "totalAmountIncludingTax" : ,
-    "status" : ,
-    "lastModifiedDateTime" : ,
-    "invoiceId" : ,
-    "invoiceNumber" : ,
-    "vendorReturnReasonId" :
+    "id": "b5fcbb14-7402-ef11-b3c3-83fe9ccecec3",
+    "number": "1004",
+    "creditMemoDate": "2024-01-08",
+    "postingDate": "2024-01-08",
+    "dueDate": "2022-02-10",
+    "vendorId": "60748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "vendorNumber": "20000",
+    "vendorName": "First Up Consultants",
+    "payToVendorId": "60748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "payToVendorNumber": "20000",
+    "payToName": "First Up Consultants",
+    "buyFromAddressLine1": "100 Day Drive",
+    "buyFromAddressLine2": "",
+    "buyFromCity": "Chicago",
+    "buyFromCountry": "US",
+    "buyFromState": "IL",
+    "buyFromPostCode": "61236",
+    "payToAddressLine1": "100 Day Drive",
+    "payToAddressLine2": "",
+    "payToCity": "Chicago",
+    "payToCountry": "US",
+    "payToState": "IL",
+    "payToPostCode": "61236",
+    "shortcutDimension1Code": "",
+    "shortcutDimension2Code": "",
+    "currencyId": "00000000-0000-0000-0000-000000000000",
+    "currencyCode": "USD",
+    "paymentTermsId": "62728e9f-8401-ef11-9f8f-6045bde9b6de",
+    "shipmentMethodId": "00000000-0000-0000-0000-000000000000",
+    "purchaser": "",
+    "pricesIncludeTax": false,
+    "discountAmount": 0,
+    "discountAppliedBeforeTax": false,
+    "totalAmountExcludingTax": 0,
+    "totalTaxAmount": 0,
+    "totalAmountIncludingTax": 0,
+    "status": "Draft",
+    "lastModifiedDateTime": "2024-04-24T19:52:07.043Z",
+    "invoiceId": "00000000-0000-0000-0000-000000000000",
+    "invoiceNumber": "",
+    "vendorReturnReasonId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED-->

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_create.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_create.md
@@ -49,35 +49,23 @@ If successful, this method returns ```201 Created``` response code and a **purch
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different. Fill in the property values -->
 ```json
-POST https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoLines({id})
+POST https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})/purchaseCreditMemoLines({id})
 Content-type: application/json
 {
-    "id" : "",
-    "documentId" : "",
-    "sequence" : "",
-    "itemId" : "",
-    "accountId" : "",
-    "lineType" : "",
-    "lineObjectNumber" : "",
-    "description" : "",
-    "unitOfMeasureId" : "",
-    "unitOfMeasureCode" : "",
-    "unitCost" : "",
-    "quantity" : "",
-    "discountAmount" : "",
-    "discountPercent" : "",
-    "discountAppliedBeforeTax" : "",
-    "amountExcludingTax" : "",
-    "taxCode" : "",
-    "taxPercent" : "",
-    "totalTaxAmount" : "",
-    "amountIncludingTax" : "",
-    "invoiceDiscountAllocation" : "",
-    "netAmount" : "",
-    "netTaxAmount" : "",
-    "netAmountIncludingTax" : "",
-    "itemVariantId" : "",
-    "locationId" : ""
+    "itemId": "64748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "accountId": "00000000-0000-0000-0000-000000000000",
+    "lineType": "Item",
+    "lineObjectNumber": "1896-S",
+    "description": "ATHENS Desk",
+    "unitOfMeasureId": "d5748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "unitOfMeasureCode": "PCS",
+    "unitCost": 780.7,
+    "quantity": 1,
+    "discountAmount": 0,
+    "discountPercent": 0,
+    "taxCode": "FURNITURE",
+    "itemVariantId": "00000000-0000-0000-0000-000000000000",
+    "locationId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->
@@ -89,32 +77,32 @@ Here is an example of the response.
 HTTP/1.1 201 Created
 Content-type: application/json
 {
-    "id" : "",
-    "documentId" : "",
-    "sequence" : "",
-    "itemId" : "",
-    "accountId" : "",
-    "lineType" : "",
-    "lineObjectNumber" : "",
-    "description" : "",
-    "unitOfMeasureId" : "",
-    "unitOfMeasureCode" : "",
-    "unitCost" : "",
-    "quantity" : "",
-    "discountAmount" : "",
-    "discountPercent" : "",
-    "discountAppliedBeforeTax" : "",
-    "amountExcludingTax" : "",
-    "taxCode" : "",
-    "taxPercent" : "",
-    "totalTaxAmount" : "",
-    "amountIncludingTax" : "",
-    "invoiceDiscountAllocation" : "",
-    "netAmount" : "",
-    "netTaxAmount" : "",
-    "netAmountIncludingTax" : "",
-    "itemVariantId" : "",
-    "locationId" : ""
+    "id": "9722e816-7602-ef11-b3c3-83fe9ccecec3",
+    "documentId": "93c20e8c-7402-ef11-b3c3-83fe9ccecec3",
+    "sequence": 10000,
+    "itemId": "64748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "accountId": "00000000-0000-0000-0000-000000000000",
+    "lineType": "Item",
+    "lineObjectNumber": "1896-S",
+    "description": "ATHENS Desk",
+    "unitOfMeasureId": "d5748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "unitOfMeasureCode": "PCS",
+    "unitCost": 780.7,
+    "quantity": 1,
+    "discountAmount": 0,
+    "discountPercent": 0,
+    "discountAppliedBeforeTax": false,
+    "amountExcludingTax": 0,
+    "taxCode": "FURNITURE",
+    "taxPercent": 5.99974,
+    "totalTaxAmount": 0,
+    "amountIncludingTax": 0,
+    "invoiceDiscountAllocation": 0,
+    "netAmount": 780.7,
+    "netTaxAmount": 46.84,
+    "netAmountIncludingTax": 827.54,
+    "itemVariantId": "00000000-0000-0000-0000-000000000000",
+    "locationId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_delete.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_delete.md
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code and delete
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different -->
 ```json
-DELETE https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoLines({id})
+DELETE https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})/purchaseCreditMemoLines({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 **Response**

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_get.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_get.md
@@ -22,7 +22,7 @@ Retrieves the properties and relationships of a purchase credit memo line object
 Replace the URL prefix for [!INCLUDE[prod_short](../../../includes/prod_short.md)] depending on environment following the [guideline](../../v2.0/endpoints-apis-for-dynamics.md).
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different -->
 ```
-GET businesscentralPrefix/companies({id})/purchaseCreditMemoLines({id})
+GET businesscentralPrefix/companies({id})/purchaseCreditMemos({id})/purchaseCreditMemoLines({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 ## Request headers
@@ -46,7 +46,7 @@ If successful, this method returns a ```200 OK``` response code and a **purchase
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different -->
 ```json
-GET https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoLines({id})
+GET https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})/purchaseCreditMemoLines({id})
 ```
 <!-- END>EDIT_IS_REQUIRED -->
 **Response**
@@ -56,32 +56,32 @@ Here is an example of the response.
 <!-- START>EDIT_IS_REQUIRED. Fill in values for properties -->
 ```json
 {
-    "id" : "",
-    "documentId" : "",
-    "sequence" : "",
-    "itemId" : "",
-    "accountId" : "",
-    "lineType" : "",
-    "lineObjectNumber" : "",
-    "description" : "",
-    "unitOfMeasureId" : "",
-    "unitOfMeasureCode" : "",
-    "unitCost" : "",
-    "quantity" : "",
-    "discountAmount" : "",
-    "discountPercent" : "",
-    "discountAppliedBeforeTax" : "",
-    "amountExcludingTax" : "",
-    "taxCode" : "",
-    "taxPercent" : "",
-    "totalTaxAmount" : "",
-    "amountIncludingTax" : "",
-    "invoiceDiscountAllocation" : "",
-    "netAmount" : "",
-    "netTaxAmount" : "",
-    "netAmountIncludingTax" : "",
-    "itemVariantId" : "",
-    "locationId" : ""
+    "id": "9722e816-7602-ef11-b3c3-83fe9ccecec3",
+    "documentId": "93c20e8c-7402-ef11-b3c3-83fe9ccecec3",
+    "sequence": 10000,
+    "itemId": "64748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "accountId": "00000000-0000-0000-0000-000000000000",
+    "lineType": "Item",
+    "lineObjectNumber": "1896-S",
+    "description": "ATHENS Desk",
+    "unitOfMeasureId": "d5748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "unitOfMeasureCode": "PCS",
+    "unitCost": 780.7,
+    "quantity": 1,
+    "discountAmount": 0,
+    "discountPercent": 0,
+    "discountAppliedBeforeTax": false,
+    "amountExcludingTax": 0,
+    "taxCode": "FURNITURE",
+    "taxPercent": 5.99974,
+    "totalTaxAmount": 0,
+    "amountIncludingTax": 0,
+    "invoiceDiscountAllocation": 0,
+    "netAmount": 780.7,
+    "netTaxAmount": 46.84,
+    "netAmountIncludingTax": 827.54,
+    "itemVariantId": "00000000-0000-0000-0000-000000000000",
+    "locationId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->

--- a/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_update.md
+++ b/dev-itpro/api-reference/v2.0/api/dynamics_purchasecreditmemoline_update.md
@@ -48,11 +48,10 @@ If successful, this method returns a ```200 OK``` response code and an updated *
 Here is an example of the request.
 <!-- START>EDIT_IS_REQUIRED. There URL for accessing the endpoint might be different. Fill in the property values) -->
 ```json
-PATCH https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemoLines({id})
+PATCH https://{businesscentralPrefix}/api/v2.0/companies({id})/purchaseCreditMemos({id})/purchaseCreditMemoLines({id})
 Content-type: application/json
 {
-    "id" : ,
-    "documentId" :
+    "quantity": 2
 }
 ```
 <!-- END>EDIT_IS_REQUIRED -->
@@ -65,32 +64,32 @@ Here is an example of the response.
 HTTP/1.1 200 OK
 Content-type: application/json
 {
-    "id" : ,
-    "documentId" : ,
-    "sequence" : ,
-    "itemId" : ,
-    "accountId" : ,
-    "lineType" : ,
-    "lineObjectNumber" : ,
-    "description" : ,
-    "unitOfMeasureId" : ,
-    "unitOfMeasureCode" : ,
-    "unitCost" : ,
-    "quantity" : ,
-    "discountAmount" : ,
-    "discountPercent" : ,
-    "discountAppliedBeforeTax" : ,
-    "amountExcludingTax" : ,
-    "taxCode" : ,
-    "taxPercent" : ,
-    "totalTaxAmount" : ,
-    "amountIncludingTax" : ,
-    "invoiceDiscountAllocation" : ,
-    "netAmount" : ,
-    "netTaxAmount" : ,
-    "netAmountIncludingTax" : ,
-    "itemVariantId" : ,
-    "locationId" :
+    "id": "9722e816-7602-ef11-b3c3-83fe9ccecec3",
+    "documentId": "93c20e8c-7402-ef11-b3c3-83fe9ccecec3",
+    "sequence": 10000,
+    "itemId": "64748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "accountId": "00000000-0000-0000-0000-000000000000",
+    "lineType": "Item",
+    "lineObjectNumber": "1896-S",
+    "description": "ATHENS Desk",
+    "unitOfMeasureId": "d5748e9f-8401-ef11-9f8f-6045bde9b6de",
+    "unitOfMeasureCode": "PCS",
+    "unitCost": 780.7,
+    "quantity": 2,
+    "discountAmount": 0,
+    "discountPercent": 0,
+    "discountAppliedBeforeTax": false,
+    "amountExcludingTax": 0,
+    "taxCode": "FURNITURE",
+    "taxPercent": 5.99974,
+    "totalTaxAmount": 0,
+    "amountIncludingTax": 0,
+    "invoiceDiscountAllocation": 0,
+    "netAmount": 1561.4,
+    "netTaxAmount": 93.68,
+    "netAmountIncludingTax": 1655.08,
+    "itemVariantId": "00000000-0000-0000-0000-000000000000",
+    "locationId": "00000000-0000-0000-0000-000000000000"
 }
 ```
 <!-- END>EDIT_IS_REQUIRED-->

--- a/dev-itpro/api-reference/v2.0/resources/dynamics_purchasecreditmemo.md
+++ b/dev-itpro/api-reference/v2.0/resources/dynamics_purchasecreditmemo.md
@@ -158,7 +158,8 @@ Here is a JSON representation of the purchaseCreditMemo resource.
 <!-- IMPORTANT: END>DO_NOT_EDIT -->
 
 ## See Also
-[GET purchaseCreditMemo](../api/dynamics_purchasecreditmemo_get.md)
-[DELETE purchaseCreditMemo](../api/dynamics_purchasecreditmemo_delete.md)
-[POST purchaseCreditMemo](../api/dynamics_purchasecreditmemo_create.md)
-[PATCH purchaseCreditMemo](../api/dynamics_purchasecreditmemo_update.md)
+
+[GET purchaseCreditMemo](../api/dynamics_purchasecreditmemo_get.md)  
+[DELETE purchaseCreditMemo](../api/dynamics_purchasecreditmemo_delete.md)  
+[POST purchaseCreditMemo](../api/dynamics_purchasecreditmemo_create.md)  
+[PATCH purchaseCreditMemo](../api/dynamics_purchasecreditmemo_update.md)  


### PR DESCRIPTION
Hello there, this PR updates the following:

- Examples (added values and removed read-only [and number, as they are provided automatically via number series] fields)
- Formatting the *See Also* section for the ressource
- Add uri prefix *purchaseCreditMemos({id})* to *purchaseCreditMemoLines*
- Rename purchaseCreditMemoes --> purchaseCreditMemos