### PR TITLE
Add note about FlowField and FlowFilter to Partial Record Methods

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-addloadfields-method.md
@@ -43,6 +43,9 @@ It is not necessary to include the following fields, because they are always sel
 
 Depending on the runtime version, the runtime may require extra fields to be selected for loading. Which extra fields to specify depends on the state of the record and table or table extension definition. For example, fields that are filtered upon are always loaded.
 
+> [!NOTE]
+> You must not use the method AddLoadFields on fields with FieldClass FlowFilter or FlowField. Otherwise a runtime error will occur.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## Example

--- a/dev-itpro/developer/methods-auto/record/record-loadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-loadfields-method.md
@@ -41,6 +41,9 @@ The FieldNo's of the fields to be loaded.
 
 This method will trigger a [JIT load](../../devenv-partial-records.md#jit) of the specified fields. The method allows for triggering the JIT load on multiple fields. If the fields are already loaded, another load will not be triggered. Using this method instead of relying on implicit JIT loads lets you develop for more explicit error handling when a load fails.
 
+> [!NOTE]
+> You must not use the method LoadFields on fields with FieldClass FlowFilter or FlowField. Otherwise a runtime error will occur.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## See Also

--- a/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-setloadfields-method.md
@@ -46,6 +46,9 @@ It is not necessary to include the following fields, because they are always sel
 
 Depending on the runtime version, the runtime may require extra fields to be selected for loading. Which extra fields to specify depends on the state of the record and table or table extension definition. For example, fields that are filtered upon are always loaded.
 
+> [!NOTE]
+> You must not use the method SetLoadFields on fields with FieldClass FlowFilter or FlowField. Otherwise a runtime error will occur.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## Example

--- a/dev-itpro/developer/methods-auto/recordref/recordref-addloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-addloadfields-method.md
@@ -42,6 +42,9 @@ The FieldNo's of the fields to be loaded.
 
 Calling SetLoadFields on a record without passing any fields will reset the fields selected to load to the default, where all readable normal fields are selected for load.
 
+> [!NOTE]
+> You must not use the method AddLoadFields on fields with FieldClass FlowFilter or FlowField. Otherwise a runtime error will occur.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## Example

--- a/dev-itpro/developer/methods-auto/recordref/recordref-loadfields-method.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-loadfields-method.md
@@ -42,6 +42,9 @@ The FieldNo's of the fields to be loaded.
 
 This method will trigger a [JIT load](../../devenv-partial-records.md#jit) of the specified fields. The method allows for triggering the JIT load on multiple fields. If the fields are already loaded, another load won't be triggered. Using this method instead of of relying on implicit JIT loads lets you develop for more explicit error handling when a load fails.
 
+> [!NOTE]
+> You must not use the method LoadFields on fields with FieldClass FlowFilter or FlowField. Otherwise a runtime error will occur.
+
 The method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
 
 ## See Also

--- a/dev-itpro/developer/methods-auto/recordref/recordref-setloadfields-method.md
+++ b/dev-itpro/developer/methods-auto/recordref/recordref-setloadfields-method.md
@@ -42,7 +42,11 @@ Calling SetLoadFields on a recordref without passing any fields will reset the f
 
 It is not necessary to include the following fields, because they are always selected for loading: Primary key, SystemId, and data audit fields (SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, SystemModifiedBy).
 
+> [!NOTE]
+> You must not use the method SetLoadFields on fields with FieldClass FlowFilter or FlowField. Otherwise a runtime error will occur.
+
 This method is part of the partial records capability for improving performance. For more information, see [Using Partial Records](../../devenv-partial-records.md).
+
 
 ## Example
 


### PR DESCRIPTION
This PR adds information to the methods for partial record loading that they result in a runtime error when they are used on FlowFields or FlowFilters.