### PR TITLE
Structuring namespaces in AL: change delimiter to comma

### DIFF
--- a/dev-itpro/developer/devenv-namespaces-structure.md
+++ b/dev-itpro/developer/devenv-namespaces-structure.md
@@ -49,7 +49,7 @@ param
     [string] $BasePath,
     [ValidateSet("Add","Ignore")]
     [string] $License = "Ignore",
-    [char] $Delimiter = ";"
+    [char] $Delimiter = ","
 )
 
 $files = Import-Csv $CsvMappingFile -Delimiter $Delimiter


### PR DESCRIPTION
The .csv sample file contains a comma as a delimiter.
The delimiter of the Powershell script is ;

This PR restores consistency so that the examples match