### PR TITLE
Added Remark to Date.Year() about difference to Date2DWY 

### DIFF
--- a/dev-itpro/developer/methods-auto/date/date-year-method.md
+++ b/dev-itpro/developer/methods-auto/date/date-year-method.md
@@ -35,7 +35,7 @@ The year.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## Remarks
-Don't use this method to replace [Date2DWY(Date, 3)](../system/system-date2dwy-method.md).
+Don't use this method to replace [`Date2DWY(Date, 3)`](../system/system-date2dwy-method.md).
 When the input date to the `Date2DWY` method is in a week that spans two years, the `Date2DWY` method computes the output year as the year that has the most days.
 The `Date.Year()` method, on the other hand, always returns the year of the date.
 

--- a/dev-itpro/developer/methods-auto/date/date-year-method.md
+++ b/dev-itpro/developer/methods-auto/date/date-year-method.md
@@ -35,7 +35,7 @@ The year.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## Remarks
-Don't use this method to replace [Date2DWY(Date, 3)](../system/system-date2dwy-method).
+Don't use this method to replace [Date2DWY(Date, 3)](../system/system-date2dwy-method.md).
 When the input date to the `Date2DWY` method is in a week that spans two years, the `Date2DWY` method computes the output year as the year that has the most days.
 The `Date.Year()` method, on the other hand, always returns the year of the date.
 

--- a/dev-itpro/developer/methods-auto/date/date-year-method.md
+++ b/dev-itpro/developer/methods-auto/date/date-year-method.md
@@ -34,6 +34,11 @@ The year.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
+## Remarks
+Don't use this method to replace [Date2DWY(Date, 3)](../system/system-date2dwy-method).
+When the input date to the `Date2DWY` method is in a week that spans two years, the `Date2DWY` method computes the output year as the year that has the most days.
+The `Date.Year()` method, on the other hand, always returns the year of the date.
+
 ## Related information
 [Date Data Type](date-data-type.md)  
 [Getting Started with AL](../../devenv-get-started.md)  


### PR DESCRIPTION
Added a remark to method `Date.Year()` to outline the difference to method `Date2DWY`