### PR TITLE
Remove duplicated guidance on applying ROBOTS metadata for Microsoft content

### DIFF
--- a/dev-itpro/deployment/configure-help.md
+++ b/dev-itpro/deployment/configure-help.md
@@ -109,8 +109,6 @@ If you deploy a solution that customizes Microsoft's default application, then y
 > [!IMPORTANT]
 > The remainder of this section is for those people who need a copy of Microsoft's content to deploy to a website along with their own content. In many cases, you don't need to customize Microsoft's content, and this section is irrelevant for you. However, if you deploy a customized solution on-premises or in a closed environment, then you might need to include Microsoft's content in your Help website.
 
-[!INCLUDE [ua-robots](../includes/ua-robots.md)]
-
 Microsoft's source files are available as downloadable packages for each major release in the [https://github.com/MicrosoftDocs/dynamics365smb-docs/](https://github.com/MicrosoftDocs/dynamics365smb-docs/releases) GitHub repo in English (US) only.
 
 > [!TIP]


### PR DESCRIPTION
This PR removes a repeated section about using ROBOTS: NOINDEX, NOFOLLOW on customized versions of Microsoft’s content.
The same guidance was included twice in the same article. I’ve kept the second instance, since it fits better with the surrounding content about copyright and styling.