### PR TITLE
Fix logical operators in conditional preprocessor directives

### DIFF
--- a/dev-itpro/developer/directives/devenv-directives-in-al.md
+++ b/dev-itpro/developer/directives/devenv-directives-in-al.md
@@ -41,7 +41,7 @@ The following conditional preprocessor directives are supported in AL.
 
 ### Logical operators in conditional directives
 
-The operators `AND`, `OR`, and `NOT` are supported in conditional directives. `AND` evaluates to `true` if both operands are true, `OR` evaluates to `true` if at least one of the operands is true, and `NOT` negates the value of the operand.
+The operators `and`, `or`, and `not` are supported in conditional directives. `and` evaluates to `true` if both operands are true, `or` evaluates to `true` if at least one of the operands is true, and `not` negates the value of the operand.
 
 ## Defining preprocessorSymbols
 


### PR DESCRIPTION
The current AL compiler does not support (and has never supportd as far as I know) the `&&`, `||`, and `!` logical operators in conditional (preprocessor) directives. These should be the (more AL native) `AND`, `OR` and `NOT` operators.