### PR TITLE
Fixed table in Truncate method documentation

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-data-type.md
+++ b/dev-itpro/developer/methods-auto/record/record-data-type.md
@@ -128,20 +128,7 @@ The following methods are available on instances of the Record data type.
 |[TestField(Any, Any, ErrorInfo)](record-testfield-joker-joker-errorinfo-method.md)|Tests whether the contents of a field match a given value.|
 |[TransferFields(var Record [, Boolean])](record-transferfields-table-boolean-method.md)|Copies all matching fields in one record to another record.|
 |[TransferFields(var Record, Boolean, Boolean)](record-transferfields-table-boolean-boolean-method.md)|Copies all matching fields in one record to another record.|
-|[Truncate([Boolean])](record-truncate-method.md)|Deletes all records in a table that fall within a specified range, in an efficient maner.
-Keep in mind that Truncate allows for less concurrency than DeleteAll, as the entire table will be locked until the transaction is committed.
-
-Truncate with a filter should only be used when the majority of the table is being deleted, as otherwise DeleteAll will be more efficient.
-
-Truncate is currently not supported in the following cases:
-- Temporary tables, system tables, and tables of type other than Normal.
-- When running within a try function.
-- Tables that have a security filter applied.
-- When the current filters contain flow fields, or use a high number of marked records.
-- When the OnAfter/OnBefore events are subscribed for the table.
-- Tables with media fields.
-
-In this case, it is recommended to use DeleteAll instead. |
+|[Truncate([Boolean])](record-truncate-method.md)|Deletes all records in a table that fall within a specified range, in an efficient maner.<br>Keep in mind that Truncate allows for less concurrency than DeleteAll, as the entire table will be locked until the transaction is committed.<br><br>Truncate with a filter should only be used when the majority of the table is being deleted, as otherwise DeleteAll will be more efficient.<br><br>Truncate is currently not supported in the following cases:<br>- Temporary tables, system tables, and tables of type other than Normal.<br>- When running within a try function.<br>- Tables that have a security filter applied.<br>- When the current filters contain flow fields, or use a high number of marked records.<br>- When the OnAfter/OnBefore events are subscribed for the table.<br>- Tables with media fields.<br><br>In this case, it is recommended to use DeleteAll instead. |
 |[Validate(Any [, Any])](record-validate-method.md)|Calls the OnValidate trigger for the field that you specify.|
 |[WritePermission()](record-writepermission-method.md)|Determines whether a user can write to a table. This method can test for both full write permission and partial write permission that has been granted with a security filter. A write permission consists of Insert, Delete, and Modify permissions.|
 


### PR DESCRIPTION
It is not allowed to use line breaks in table cells as they break the table layout. Fixed using HTML tags.