### PR TITLE
Update codecop-aa0249.md with fix instructions

### DIFF
--- a/dev-itpro/developer/analyzers/codecop-aa0249.md
+++ b/dev-itpro/developer/analyzers/codecop-aa0249.md
@@ -17,6 +17,9 @@ PageField trigger is unused due to a property value.
 PageField trigger is unused due to a property value.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
+## How to fix this diagnostic?
+The warning may be triggered for the [`OnLookup` trigger](../triggers-auto/pagefield/devenv-onlookup-pagefield-trigger.md) while the page field is not editable. In such cases, it is best practice to replace the `OnLookup` trigger with the [`OnDrillDown` trigger](../triggers-auto/pagefield/devenv-ondrilldown-pagefield-trigger.md).
+
 ## Related information  
 [CodeCop analyzer](codecop.md)  
 [Getting started with AL](../devenv-get-started.md)  


### PR DESCRIPTION
Added guidance on fixing unused PageField trigger warning. (As further fix instructions might be added in the future, a table might be required instead.)