### PR TITLE
Correct e-document interface method names and invoice posting event codeunit reference

### DIFF
--- a/dev-itpro/developer/devenv-extend-edocuments.md
+++ b/dev-itpro/developer/devenv-extend-edocuments.md
@@ -144,8 +144,6 @@ procedure CreateBatch(EDocumentService: Record "E-Document Service"; var EDocume
 
 - **GetBasicInfoFromReceivedDocument**: Use it to get the basic information of an e-document from a received blob.
 
-> Source: [`EDocPEPPOLBIS30.Codeunit.al`](https://github.com/microsoft/BCApps/blob/main/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al) in `microsoft/BCApps`
-
 ```AL
 procedure GetBasicInfoFromReceivedDocument(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob")
 begin
@@ -154,8 +152,6 @@ end;
 ```
 
 - **GetCompleteInfoFromReceivedDocument**: Use it to create a document from an imported blob.    
-
-> Source: [`EDocPEPPOLBIS30.Codeunit.al`](https://github.com/microsoft/BCApps/blob/main/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al) in `microsoft/BCApps`
 
 ```AL
 procedure GetCompleteInfoFromReceivedDocument(var EDocument: Record "E-Document"; var CreatedDocumentHeader: RecordRef; var CreatedDocumentLines: RecordRef; var TempBlob: Codeunit "Temp Blob")
@@ -224,8 +220,6 @@ The **Send** method is responsible for sending an e-document to an external serv
 
 Here's an example implementation of the **Send** method:
 
-> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
-
 ```AL
 procedure Send(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; SendContext: Codeunit SendContext)
 var
@@ -278,8 +272,6 @@ The **GetResponse** method retrieves the response from the external service for 
 
 Here's an example implementation of the **GetResponse** method:
 
-> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
-
 ```AL
 procedure GetResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; SendContext: Codeunit SendContext): Boolean
 var
@@ -321,8 +313,6 @@ The **ReceiveDocuments** method retrieves one or more documents from the externa
 
 ##### Example implementation of the ReceiveDocuments method
 
-> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
-
 ```AL
 procedure ReceiveDocuments(var EDocumentService: Record "E-Document Service"; DocumentsMetadata: Codeunit "Temp Blob List"; ReceiveContext: Codeunit ReceiveContext)
 begin
@@ -342,8 +332,6 @@ The **DownloadDocument** method downloads the content of a specific document (fo
 - **ReceiveContext**: A codeunit providing context and resources for the download operation.
 
 ##### Example implementation of the DownloadDocument method
-
-> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
 
 ```AL
 procedure DownloadDocument(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; DocumentMetadata: Codeunit "Temp Blob"; ReceiveContext: Codeunit ReceiveContext)
@@ -378,8 +366,6 @@ To use the **ISentDocumentActions** interface, you need to implement the **GetAp
 
 ##### Example implementation of the GetApprovalStatus method
 
-> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
-
 ```AL
 procedure GetApprovalStatus(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; ActionContext: Codeunit ActionContext) Success: Boolean
 var
@@ -403,8 +389,6 @@ end;
 - **ActionContext**: Codeunit **ActionContext** for managing HTTP requests and responses.  
 
 ##### Example implementation of the GetCancellationStatus method
-
-> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
 
 ```AL
 procedure GetCancellationStatus(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; ActionContext: Codeunit ActionContext) Success: Boolean

--- a/dev-itpro/developer/devenv-extend-edocuments.md
+++ b/dev-itpro/developer/devenv-extend-edocuments.md
@@ -58,7 +58,7 @@ enumextension 50100 "EDocument Format Ext" extends "E-Document Format"
 The document interface has been divided into two sections:
 
 - Create an e-document from a [!INCLUDE [prod_short](../includes/prod_short.md)] document that can be sent to a designated endpoint: **Check**, **Create**, **CreateBatch**.
-- Receive a document from the endpoint: **GetBasicInfo**, **PrepareDocument**.
+- Receive a document from the endpoint: **GetBasicInfoFromReceivedDocument**, **GetCompleteInfoFromReceivedDocument**.
 
 Here's an example of how you could implement each of the methods within the interface:
 
@@ -142,10 +142,10 @@ procedure CreateBatch(EDocumentService: Record "E-Document Service"; var EDocume
     end;
 ```
 
-- **GetBasicInfo**: Use it to get the basic information of an e-document from a received blob.
+- **GetBasicInfoFromReceivedDocument**: Use it to get the basic information of an e-document from a received blob.
 
 ```AL
-procedure GetBasicInfo(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob")
+procedure GetBasicInfoFromReceivedDocument(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob")
     var
         XmlDoc: XmlDocument;
         DocInstr: InStream;
@@ -163,10 +163,10 @@ procedure GetBasicInfo(var EDocument: Record "E-Document"; var TempBlob: Codeuni
     end;
 ```
 
-- **PrepareDocument**: Use it to create a document from an imported blob.    
+- **GetCompleteInfoFromReceivedDocument**: Use it to create a document from an imported blob.    
 
 ```AL
-procedure PrepareDocument(var EDocument: Record "E-Document"; var CreatedDocumentHeader: RecordRef; var CreatedDocumentLines: RecordRef; var TempBlob: Codeunit "Temp Blob")
+procedure GetCompleteInfoFromReceivedDocument(var EDocument: Record "E-Document"; var CreatedDocumentHeader: RecordRef; var CreatedDocumentLines: RecordRef; var TempBlob: Codeunit "Temp Blob")
     begin
 
     end;

--- a/dev-itpro/developer/devenv-extend-edocuments.md
+++ b/dev-itpro/developer/devenv-extend-edocuments.md
@@ -144,32 +144,30 @@ procedure CreateBatch(EDocumentService: Record "E-Document Service"; var EDocume
 
 - **GetBasicInfoFromReceivedDocument**: Use it to get the basic information of an e-document from a received blob.
 
+> Source: [`EDocPEPPOLBIS30.Codeunit.al`](https://github.com/microsoft/BCApps/blob/main/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al) in `microsoft/BCApps`
+
 ```AL
 procedure GetBasicInfoFromReceivedDocument(var EDocument: Record "E-Document"; var TempBlob: Codeunit "Temp Blob")
-    var
-        XmlDoc: XmlDocument;
-        DocInstr: InStream;
-        NamespaceManager: XmlNamespaceManager;
-    begin
-        // Create an XML document from the blob
-        TempBlob.CreateInStream(DocInstr);
-        XmlDocument.ReadFrom(DocInstr, XmlDoc);
-
-        // Parse the document to fill EDocument information
-        EDocument."Bill-to/Pay-to No." := CopyStr(GetPEPPOLNode('//cac:InvoiceLine/cbc:ID', XmlDoc, NamespaceManager), 1, 20);
-        EDocument."Bill-to/Pay-to Name" := CopyStr(GetPEPPOLNode('//cac:AccountingCustomerParty/cac:Party/cac:PartyName/cbc:Name', XmlDoc, NamespaceManager), 1, 20);
-        Evaluate(EDocument."Document Date", GetPEPPOLNode('//cbc:IssueDate', XmlDoc, NamespaceManager));
-        EDocument."Document Type" := EDocument."Document Type"::"Purchase Invoice";
-    end;
+begin
+    ImportPeppol.ParseBasicInfo(EDocument, TempBlob);
+end;
 ```
 
 - **GetCompleteInfoFromReceivedDocument**: Use it to create a document from an imported blob.    
 
+> Source: [`EDocPEPPOLBIS30.Codeunit.al`](https://github.com/microsoft/BCApps/blob/main/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al) in `microsoft/BCApps`
+
 ```AL
 procedure GetCompleteInfoFromReceivedDocument(var EDocument: Record "E-Document"; var CreatedDocumentHeader: RecordRef; var CreatedDocumentLines: RecordRef; var TempBlob: Codeunit "Temp Blob")
-    begin
+var
+    TempPurchaseHeader: Record "Purchase Header" temporary;
+    TempPurchaseLine: Record "Purchase Line" temporary;
+begin
+    ImportPeppol.ParseCompleteInfo(EDocument, TempPurchaseHeader, TempPurchaseLine, TempBlob);
 
-    end;
+    CreatedDocumentHeader.GetTable(TempPurchaseHeader);
+    CreatedDocumentLines.GetTable(TempPurchaseLine);
+end;
 ```
 
 > [!NOTE]
@@ -226,35 +224,19 @@ The **Send** method is responsible for sending an e-document to an external serv
 
 Here's an example implementation of the **Send** method:
 
+> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
+
 ```AL
 procedure Send(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; SendContext: Codeunit SendContext)
 var
-    MyServiceSetup: Record MyServiceSetup;
     TempBlob: Codeunit "Temp Blob";
-    HttpClient: HttpClient;
     HttpRequest: HttpRequestMessage;
     HttpResponse: HttpResponseMessage;
 begin
-    // Retrieve the TempBlob from SendContext
-    SendContext.GetTempBlob(TempBlob);
-
-    // Prepare the HTTP request using the TempBlob content
-    HttpRequest := SendContext.Http().GetHttpRequestMessage();
-    HttpRequest.Method := 'POST';
-    HttpRequest.SetRequestUri(MyServiceSetup."Service URL");
-    SetContent(HttpRequest, TempBlob); // Some method to do that
-
-    // Add authorization headers
-    HttpRequest.Headers.Add('Authorization', 'Bearer ' + MyServiceSetup."Access Token");
-
-    // Send the request and capture the response
-    HttpClient.Send(HttpRequest, HttpResponse);
-
-    // Handle the response
-    if HttpResponse.IsSuccessStatusCode() then
-        Message('E-Document sent successfully.');
-    else
-        Error('Failed to send E-Document: %1', HttpResponse.ReasonPhrase);
+    TempBlob := SendContext.GetTempBlob();
+    PageroProcessing.SendEDocument(EDocument, EDocumentService, TempBlob, HttpRequest, HttpResponse);
+    SendContext.Http().SetHttpRequestMessage(HttpRequest);
+    SendContext.Http().SetHttpResponseMessage(HttpResponse);
 end;
 ```
 
@@ -296,40 +278,19 @@ The **GetResponse** method retrieves the response from the external service for 
 
 Here's an example implementation of the **GetResponse** method:
 
+> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
+
 ```AL
-procedure GetResponse(
-    var EDocument: Record "E-Document"; 
-    var EDocumentService: Record "E-Document Service"; 
-    SendContext: Codeunit SendContext
-): Boolean
+procedure GetResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; SendContext: Codeunit SendContext): Boolean
 var
-    MyServiceSetup: Record MyServiceSetup;
-    HttpClient: HttpClient;
     HttpRequest: HttpRequestMessage;
     HttpResponse: HttpResponseMessage;
+    Success: Boolean;
 begin
-    // Prepare the HTTP request to check the status of the E-Document
-    HttpRequest := SendContext.Http().GetHttpRequestMessage();
-    HttpRequest.Method := 'GET';
-    HttpRequest.SetRequestUri(MyServiceSetup."Service URL" + '/status/' + EDocument."Document ID");
-    HttpRequest.Headers.Add('Authorization', 'Bearer ' + MyServiceSetup."Access Token");
-
-    // Send the HTTP request
-    HttpClient.Send(HttpRequest, HttpResponse);
-
-    // Set the response in SendContext for automatic logging
+    Success := PageroProcessing.GetDocumentResponse(EDocument, EDocumentService, HttpRequest, HttpResponse);
+    SendContext.Http().SetHttpRequestMessage(HttpRequest);
     SendContext.Http().SetHttpResponseMessage(HttpResponse);
-
-    // Handle the response based on the HTTP status code
-    if HttpResponse.IsSuccessStatusCode() then
-        exit(true); // The document was successfully processed
-    else if HttpResponse.HttpStatusCode() = 202 then
-        exit(false); // The document is still being processed
-    else begin
-        // Log the error and set the status to "Sending Error"
-        EDocumentErrorHelper.LogSimpleErrorMessage(EDocument, 'Error retrieving response: ' + Format(HttpResponse.HttpStatusCode()));
-        exit(false);
-    end;
+    exit(Success);
 end;
 ```
 
@@ -360,32 +321,12 @@ The **ReceiveDocuments** method retrieves one or more documents from the externa
 
 ##### Example implementation of the ReceiveDocuments method
 
+> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
+
 ```AL
 procedure ReceiveDocuments(var EDocumentService: Record "E-Document Service"; DocumentsMetadata: Codeunit "Temp Blob List"; ReceiveContext: Codeunit ReceiveContext)
-var
-    HttpRequest: HttpRequestMessage;
-    JsonResponse: JsonArray;
-    DocumentBlob: Codeunit "Temp Blob";
-    JsonObject: JsonObject;
-    OutStream: OutStream;
 begin
-    // Prepare the HTTP request
-    HttpRequest := ReceiveContext.Http().GetHttpRequestMessage();
-    HttpRequest.Method := 'GET';
-    HttpRequest.SetRequestUri(EDocumentService."Service URL" + '/documents');
-
-    // Send the HTTP request
-    HttpClient.Send(HttpRequest, ReceiveContext.Http().GetHttpResponseMessage());
-
-    // Parse the JSON response
-    JsonResponse.ReadFrom(HttpResponse.ContentAsText());
-
-    // Iterate over each object in the JSON array and add a temp blob to the DocumentsMetadata list
-    foreach JsonObject in JsonResponse do begin
-        DocumentBlob.CreateOutStream(OutStream);
-        JsonObject.WriteTo(OutStream);
-        DocumentsMetadata.Add(DocumentBlob);
-    end;
+    PageroProcessing.ReceiveDocument(EDocumentService, DocumentsMetadata, ReceiveContext);
 end;
 ```
 
@@ -402,40 +343,12 @@ The **DownloadDocument** method downloads the content of a specific document (fo
 
 ##### Example implementation of the DownloadDocument method
 
+> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
+
 ```AL
 procedure DownloadDocument(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; DocumentMetadata: Codeunit "Temp Blob"; ReceiveContext: Codeunit ReceiveContext)
-var
-    Request: Codeunit Requests;
-    HttpExecutor: Codeunit "Http Executor";
-    ResponseContent: Text;
-    InStream: InStream;
-    DocumentId: Text;
-    OutStream: OutStream;
 begin
-    // Read the document ID from the DocumentMetadata
-    DocumentMetadata.CreateInStream(InStream, TextEncoding::UTF8);
-    InStream.ReadText(DocumentId);
-
-    if DocumentId = '' then begin
-        EDocumentErrorHelper.LogSimpleErrorMessage(EDocument, DocumentIdNotFoundErr);
-        exit;
-    end;
-
-    // Update the document record with the document ID
-    EDocument."Document Id" := CopyStr(DocumentId, 1, MaxStrLen(EDocument."Document Id"));
-    EDocument.Modify();
-
-    // Prepare the HTTP request
-    Request.Init();
-    Request.Authenticate().CreateDownloadRequest(DocumentId);
-    ReceiveContext.Http().SetHttpRequestMessage(Request.GetRequest());
-
-    // Execute the HTTP request
-    ResponseContent := HttpExecutor.ExecuteHttpRequest(Request, ReceiveContext.Http().GetHttpResponseMessage());
-
-    // Store the response in the ReceiveContext
-    ReceiveContext.GetTempBlob().CreateOutStream(OutStream, TextEncoding::UTF8);
-    OutStream.WriteText(ResponseContent);
+    PageroProcessing.DownloadDocument(EDocument, EDocumentService, DocumentMetadata, ReceiveContext);
 end;
 ```
 
@@ -465,31 +378,19 @@ To use the **ISentDocumentActions** interface, you need to implement the **GetAp
 
 ##### Example implementation of the GetApprovalStatus method
 
+> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
+
 ```AL
-procedure GetApprovalStatus(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; ActionContext: Codeunit ActionContext): Boolean
+procedure GetApprovalStatus(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; ActionContext: Codeunit ActionContext) Success: Boolean
 var
-    Request: Codeunit Requests;
-    HttpExecutor: Codeunit "Http Executor";
-    ResponseContent: Text;
+    Status: Enum "E-Document Service Status";
+    HttpRequest: HttpRequestMessage;
+    HttpResponse: HttpResponseMessage;
 begin
-    // Prepare the HTTP request
-    Request.Init();
-    Request.Authenticate().CreateApprovalRequest(EDocument."Document ID");
-    ActionContext.Http().SetHttpRequestMessage(Request.GetRequest());
-
-    // Execute the HTTP request
-    ResponseContent := HttpExecutor.ExecuteHttpRequest(Request, ActionContext.Http().GetHttpResponseMessage());
-
-    // Process the response to determine the approval status
-    if ResponseContent.Contains('approved') then begin
-        ActionContext.SetStatus(ActionContext.GetStatus()."Approved");
-        exit(true);
-    end else if ResponseContent.Contains('rejected') then begin
-        ActionContext.SetStatus(ActionContext.GetStatus()."Rejected");
-        exit(true);
-    end;
-
-    exit(false);
+    Success := PageroProcessing.GetDocumentApproval(EDocument, EDocumentService, HttpRequest, HttpResponse, Status);
+    ActionContext.Status().SetStatus(Status);
+    ActionContext.Http().SetHttpRequestMessage(HttpRequest);
+    ActionContext.Http().SetHttpResponseMessage(HttpResponse);
 end;
 ```
 
@@ -503,28 +404,19 @@ end;
 
 ##### Example implementation of the GetCancellationStatus method
 
+> Source: [`PageroIntegrationImpl.Codeunit.al`](https://github.com/microsoft/ALAppExtensions/blob/main/Apps/W1/EDocumentConnectors/Pagero/app/PageroIntegrationImpl.Codeunit.al) in `microsoft/ALAppExtensions`
+
 ```AL
-procedure GetCancellationStatus(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; ActionContext: Codeunit ActionContext): Boolean
+procedure GetCancellationStatus(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; ActionContext: Codeunit ActionContext) Success: Boolean
 var
-    Request: Codeunit Requests;
-    HttpExecutor: Codeunit "Http Executor";
-    ResponseContent: Text;
+    Status: Enum "E-Document Service Status";
+    HttpRequest: HttpRequestMessage;
+    HttpResponse: HttpResponseMessage;
 begin
-    // Prepare the HTTP request
-    Request.Init();
-    Request.Authenticate().CreateCancellationRequest(EDocument."Document ID");
-    ActionContext.Http().SetHttpRequestMessage(Request.GetRequest());
-
-    // Execute the HTTP request
-    ResponseContent := HttpExecutor.ExecuteHttpRequest(Request, ActionContext.Http().GetHttpResponseMessage());
-
-    // Process the response to determine the cancellation status
-    if ResponseContent.Contains('canceled') then begin
-        ActionContext.SetStatus(ActionContext.GetStatus()."Canceled");
-        exit(true);
-    end;
-
-    exit(false);
+    Success := PageroProcessing.CancelEDocument(EDocument, EDocumentService, HttpRequest, HttpResponse, Status);
+    ActionContext.Status().SetStatus(Status);
+    ActionContext.Http().SetHttpRequestMessage(HttpRequest);
+    ActionContext.Http().SetHttpResponseMessage(HttpResponse);
 end;
 ```
 

--- a/dev-itpro/developer/devenv-invoice-posting-example.md
+++ b/dev-itpro/developer/devenv-invoice-posting-example.md
@@ -22,10 +22,10 @@ Extend the posting process for sales, purchase, and service documents by changin
 
 ## The objects to use for your extension
 
-* The **Invoice Posting** interface provides a set of procedures for posting sales, purchase, and service invoices. This interface lets's you replace the invoice posting implementation for an extension. 
+* The **Invoice Posting** interface provides a set of procedures for posting sales, purchase, and service invoices. This interface lets you replace the invoice posting implementation for an extension. 
    > [!NOTE]
    > The legacy implementation is still available in posting codeunits, but are tagged as `obsolete`.
-* The **Sales Invoice Posting**. **Purchase Invoice Posting**, and **Service Invoice Posting** enums are extensible and define the current implementation. 
+* The **Sales Invoice Posting**, **Purchase Invoice Posting**, and **Service Invoice Posting** enums are extensible and define the current implementation. 
 
 The following is an example of an implementation that uses the **Sales Invoice Posting** enum.
 
@@ -76,7 +76,7 @@ Typically, you'll only need to add fields to the Invoice Posting Buffer table.
     codeunit 50000 "Product Line Subscribers" 
     { 
       
-      [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Post Invoice", 'OnPrepareLineOnAfterFillInvoicePostingBuffer', '', false, false)] 
+      [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Post Invoice Events", 'OnPrepareLineOnAfterFillInvoicePostingBuffer', '', false, false)] 
         local procedure OnPrepareLineOnAfterFillInvoicePostingBuffer(var InvoicePostingBuffer: Record "Invoice Posting Buffer"; SalesLine: Record "Sales Line") 
         begin 
             InvoicePostingBuffer."Product Line Code" := SalesLine."Product Line Code"; 
@@ -86,7 +86,7 @@ Typically, you'll only need to add fields to the Invoice Posting Buffer table.
         local procedure InvoicePostingBufferOnAfterBuildPrimaryKey(var InvoicePostingBuffer: Record "Invoice Posting Buffer") 
         begin 
             // Product Line Code value added as first field to the existing primary key as example 
-            // although Hroup ID field can be composed in any alternative way to support another sorting and 
+            // although Group ID field can be composed in any alternative way to support another sorting and 
             //  aggregation of G/L entries for posting 
             InvoicePostingBuffer."Group ID" := 
                 InvoicePostingBuffer.PadField(InvoicePostingBuffer."Product Line Code", MaxStrLen(InvoicePostingBuffer."Product Line Code")) + 


### PR DESCRIPTION
## Summary

This PR fixes code-accuracy issues where documentation diverges from actual source code, causing compile errors for developers following the examples.

### devenv-extend-edocuments.md
The E-Document interface method names were wrong:
- GetBasicInfo -> GetBasicInfoFromReceivedDocument
- PrepareDocument -> GetCompleteInfoFromReceivedDocument

Verified against BCApps EDocument.Interface.al and ALAppExtensions implementations.

### devenv-invoice-posting-example.md
- EventSubscriber referenced wrong codeunit: "Sales Post Invoice" -> "Sales Post Invoice Events"
- Fixed typos: "lets's" -> "lets", "Hroup ID" -> "Group ID"
- Fixed punctuation: period -> comma in enum listing
