### PR TITLE
Fix compile errors in API page and workflow walkthrough code examples

### DIFF
--- a/dev-itpro/developer/devenv-api-pagetype.md
+++ b/dev-itpro/developer/devenv-api-pagetype.md
@@ -65,9 +65,10 @@ page 50120 MyCustomerApi
         {
             repeater(GroupName)
             {
-                field(id; Id)
+                field(id; Rec.SystemId)
                 {
-                    Caption = 'ID';
+                    Caption = 'Id';
+                    Editable = false;
                 }
                 field(name; Name)
                 {

--- a/dev-itpro/developer/devenv-walkthrough-workflow-events-responses.md
+++ b/dev-itpro/developer/devenv-walkthrough-workflow-events-responses.md
@@ -100,7 +100,7 @@ The following code illustrates the new method in the `MyWorkflowEvents` codeunit
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Workflow Event Handling", 'OnAddWorkflowEventsToLibrary', '', true, true)]
     procedure AddMyWorkflowEventsToLibrary()
     var
-        WorkflowEventHandling: Codeunit"Workflow Event Handling";
+        WorkflowEventHandling: Codeunit "Workflow Event Handling";
     begin
         WorkflowEventHandling.AddEventToLibrary(MyWorkflowEventCode(), Database::"Purchase Header", 'My workflow event description', 0, false);
     end;


### PR DESCRIPTION
Fix two compile errors in AL code examples.

devenv-api-pagetype.md: field(id; Id) references a non-existent field on the Customer table. All real APIV2 pages use Rec.SystemId for the id field. Also corrects Caption from 'ID' to 'Id' to match APIV2 casing convention, and adds Editable = false per the same pattern.

devenv-walkthrough-workflow-events-responses.md: Missing space between Codeunit keyword and string literal. Codeunit"Workflow Event Handling" is invalid AL syntax and will not compile. Should be Codeunit "Workflow Event Handling".
