### PR TITLE
Add deprecation note for with statement in item charges example

### DIFF
--- a/dev-itpro/developer/devenv-extending-item-charges.md
+++ b/dev-itpro/developer/devenv-extending-item-charges.md
@@ -69,6 +69,9 @@ codeunit 50100 "Item Ch. Assign by Fairy Dust"
 ## To add a new distribution method for item charges
 In the new codeunit, add functions to distribute the charges over the item lines.
 
+> [!NOTE]
+> The `GetItemValues` procedure in the example below uses a `with` statement, which is deprecated since Business Central 2020 release wave 2. In new code, qualify field access with the record variable name instead. Learn more in [Deprecating explicit and implicit with statements](devenv-deprecating-with-statements-overview.md).
+
 ```AL
     local procedure AssignByFairyDust(var ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)"; Currency: Record Currency; TotalQtyToAssign: Decimal; TotalAmtToAssign: Decimal)
     var


### PR DESCRIPTION
Add deprecation note for with statement usage in the item charge distribution example.

devenv-extending-item-charges.md: The GetItemValues procedure in the walkthrough uses a with statement (with TempItemChargeAssgntPurch do) with no indication it is deprecated. The with statement has been deprecated since Business Central 2020 release wave 2 (AL0606 warning). Without a note, developers copy this pattern into new code and immediately get deprecation warnings.

Added a NOTE callout before the code block pointing to the deprecating-with-statements-overview article.
