### PR TITLE
Remove doubled words in telemetry documentation

### DIFF
--- a/dev-itpro/administration/telemetry-database-locks-trace.md
+++ b/dev-itpro/administration/telemetry-database-locks-trace.md
@@ -1,6 +1,6 @@
 ---
 title: Database Lock Timeout Trace Telemetry | Microsoft Docs
-description: Learn about the database lock timeout Trace Telemetry telemetry in Business Central  
+description: Learn about the database lock timeout telemetry in Business Central  
 author: jswymer
 ms.topic: how-to
 ms.devlang: al

--- a/dev-itpro/administration/telemetry-environment-lifecycle-trace.md
+++ b/dev-itpro/administration/telemetry-environment-lifecycle-trace.md
@@ -1097,7 +1097,7 @@ Occurs when the operation to move the environment to a different Entra tenant st
 
 |Dimension|Description or value|
 |---------|-----|
-|message|**Environment move to {destinationAadTenantId} AAD tenant operation operation started: {sourceEnvironmentName}** <br /><br /> `{sourceEnvironmentName}` indicates the name of the environment to be moved.<br /><br /> `{destinationAadTenantId}` indicates the destination Entra tenant.|
+|message|**Environment move to {destinationAadTenantId} AAD tenant operation started: {sourceEnvironmentName}** <br /><br /> `{sourceEnvironmentName}` indicates the name of the environment to be moved.<br /><br /> `{destinationAadTenantId}` indicates the destination Entra tenant.|
 
 ### Custom dimensions
 

--- a/dev-itpro/administration/telemetry-financial-report-lifecycle-trace.md
+++ b/dev-itpro/administration/telemetry-financial-report-lifecycle-trace.md
@@ -610,7 +610,7 @@ traces
 
 ## Financial report definition imported: {Report Definition Code}
 
-Occurs when a user imports a financial report report definition.
+Occurs when a user imports a financial report definition.
 
 ### General dimensions
 
@@ -649,7 +649,7 @@ traces
 
 ## Financial report definition exported: {Report Definition Code}
 
-Occurs when a user exports a financial report report definition.
+Occurs when a user exports a financial report definition.
 
 ### General dimensions
 
@@ -688,7 +688,7 @@ traces
 
 ## Financial report definition modified: {Report Definition Code}
 
-Occurs when a user modifies a financial report report definition.
+Occurs when a user modifies a financial report definition.
 
 ### General dimensions
 
@@ -727,7 +727,7 @@ traces
 
 ## Financial report definition deleted: {Report Definition Code}
 
-Occurs when a user deletes a financial report report definition.
+Occurs when a user deletes a financial report definition.
 
 ### General dimensions
 

--- a/dev-itpro/administration/telemetry-job-queue-lifecycle-trace.md
+++ b/dev-itpro/administration/telemetry-job-queue-lifecycle-trace.md
@@ -357,7 +357,7 @@ In the table below, you can read more about the scenarios and get sample KQL cod
 | Condition | Area | Relevant for | Description | Event Id(s) | KQL sample code (*CTRL+click* to open in new page) |
 | --------- | -----| ------------ | ----------- | --------------- | ------------ |
 | Job queue errors | Errors | VAR | Get alerted on job queue entries fail. | AL0000E26 | [JobQueueFailures.kql](https://github.com/microsoft/BCTech/blob/master/samples/AppInsights/Alerts/AlertingKQLSamples/JobQueueFailures.kql) |
-| Job queue stopped due to errors errors | Errors | VAR | Get alerted on job queue entries that are stopped due to recurring errors (because they have failed for all retry attempts). | AL0000JRG | [JobQueueFailures.kql](https://github.com/microsoft/BCTech/blob/master/samples/AppInsights/Alerts/AlertingKQLSamples/JobQueueFailures.kql) |
+| Job queue stopped due to errors | Errors | VAR | Get alerted on job queue entries that are stopped due to recurring errors (because they have failed for all retry attempts). | AL0000JRG | [JobQueueFailures.kql](https://github.com/microsoft/BCTech/blob/master/samples/AppInsights/Alerts/AlertingKQLSamples/JobQueueFailures.kql) |
 | Job queue not running | Errors | VAR | Get alerted if no job queue entries have been started in a given time period. | AL0000E26 | [NoJobQueueRuns.kql](https://github.com/microsoft/BCTech/blob/master/samples/AppInsights/Alerts/AlertingKQLSamples/NoJobQueueRuns.kql) |
 
 


### PR DESCRIPTION
Fixes duplicate words across four telemetry trace files: 'Trace Telemetry telemetry' in database-locks description, 'operation operation' in environment lifecycle, 'report report' (four occurrences) in financial report lifecycle, and 'errors errors' in job queue lifecycle.