### PR TITLE
Remove doubled 'the' in AppSourceCop rule descriptions

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0080.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0080.md
@@ -34,7 +34,7 @@ The validation of the length of table fields was previously done with [AS0004](a
 ## How to fix this diagnostic?
 
 Reverting the change will fix this diagnostic. If decreasing the length of the field is required, the recommended approach is to mark the field as [Obsolete Pending](../properties/devenv-obsoletestate-property.md) and introduce a new field with the desired length.
-Once all dependent extensions have uptaken the new field, you can mark the the original one as [Obsolete Removed](../properties/devenv-obsoletestate-property.md).
+Once all dependent extensions have uptaken the new field, you can mark the original one as [Obsolete Removed](../properties/devenv-obsoletestate-property.md).
 
 
 ## Code examples triggering the rule

--- a/dev-itpro/developer/analyzers/appsourcecop-as0128.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0128.md
@@ -11,7 +11,7 @@ ms.reviewer: solsen
 [//]: # (IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT.)
 [//]: # (Any modifications should be made in the .xml files in the ModernDev repo.)
 # AppSourceCop Error AS0128
-An interface must not be removed from the the list of extended interfaces on an interface that has been published.
+An interface must not be removed from the list of extended interfaces on an interface that has been published.
 
 ## Description
 An interface must not be removed from the list of extended interfaces on an interface that has been published, because dependent extensions may break

--- a/dev-itpro/developer/analyzers/appsourcecop-as0129.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0129.md
@@ -11,7 +11,7 @@ ms.reviewer: solsen
 [//]: # (IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT.)
 [//]: # (Any modifications should be made in the .xml files in the ModernDev repo.)
 # AppSourceCop Error AS0129
-An interface must not be added to the the list of extended interfaces on an interface that has been published.
+An interface must not be added to the list of extended interfaces on an interface that has been published.
 
 ## Description
 An interface must not be added to the list of extended interfaces on an interface that has been published, because dependent extensions may break

--- a/dev-itpro/developer/analyzers/appsourcecop.md
+++ b/dev-itpro/developer/analyzers/appsourcecop.md
@@ -138,7 +138,7 @@ AppSourceCop is an analyzer that enforces rules that must be respected by extens
 |[AS0125](appsourcecop-as0125.md)|Changes the XLIFF translation ID are not allowed.|Upgrade|Info|
 |[AS0126](appsourcecop-as0126.md)|InternalsVisibleTo should not specifying a different publisher name than the one of this extension.|Extensibility|Warning|
 |[AS0127](appsourcecop-as0127.md)|Objects should be placed in a namespace with at least two levels.|Extensibility|Warning|
-|[AS0128](appsourcecop-as0128.md)|An interface must not be removed from the the list of extended interfaces on an interface that has been published.|Upgrade|Error|
+|[AS0128](appsourcecop-as0128.md)|An interface must not be removed from the list of extended interfaces on an interface that has been published.|Upgrade|Error|
 |[AS0129](appsourcecop-as0129.md)|An interface must not be added to the the list of extended interfaces on an interface that has been published.|Upgrade|Error|
 |[AS0130](appsourcecop-as0130.md)|Avoid using duplicate object names|Extensibility|Warning|
 |[AS0131](appsourcecop-as0131.md)|Tables with schema should not be added.|Upgrade|Hidden|


### PR DESCRIPTION
Four AppSourceCop analyzer files contain 'the the' in rule description text. Fixes AS0080 ('mark the the original'), AS0128 ('removed from the the list'), AS0129 ('added to the the list'), and the summary table in appsourcecop.md (two occurrences).