### PR TITLE
Remove doubled words in developer documentation

### DIFF
--- a/dev-itpro/developer/attributes/devenv-eventsubscriber-attribute.md
+++ b/dev-itpro/developer/attributes/devenv-eventsubscriber-attribute.md
@@ -37,7 +37,7 @@ Specifies the type of object that publishes the event to subscribe to.
 
 *ObjectId*  
 &emsp;Type: [Integer](../methods-auto/integer/integer-data-type.md)  
-Specifies the ID of the object that that publishes the event to subscribe to. You can specify the object by its ID (integer) or by its name using the syntax `<ObjectType>::<ObjectName>`, such as `Codeunit::MyEventPublisher`. Using the name is the recommended way.  
+Specifies the ID of the object that publishes the event to subscribe to. You can specify the object by its ID (integer) or by its name using the syntax `<ObjectType>::<ObjectName>`, such as `Codeunit::MyEventPublisher`. Using the name is the recommended way.  
 
 *EventName*  
 &emsp;Type: [Text](../methods-auto/text/text-data-type.md)  

--- a/dev-itpro/developer/devenv-al-control-statements.md
+++ b/dev-itpro/developer/devenv-al-control-statements.md
@@ -573,7 +573,7 @@ var
 
 [!INCLUDE [2025rw1_and_later](includes/2025rw1_and_later.md)]
 
-With [!INCLUDE [prod_short](../includes/prod_short.md)] runtime 15.0, you can use the the `continue` statement to proceed to the next iteration of the iterative statement in which it appears.  
+With [!INCLUDE [prod_short](../includes/prod_short.md)] runtime 15.0, you can use the `continue` statement to proceed to the next iteration of the iterative statement in which it appears.  
 
 ```AL
 continue;  

--- a/dev-itpro/developer/devenv-designing-user-interfaces.md
+++ b/dev-itpro/developer/devenv-designing-user-interfaces.md
@@ -71,7 +71,7 @@ For more information, see [Designing views](devenv-views.md)
 
 ## Queries
 
-Available from version 23, users can view and analyze query data directly from the [!INCLUDE[prod_short](includes/prod_short.md)] client in analysis mode. The data is analyzed in real time and respects the data security that has been set up for the users. Just like for pages, you can can make queries discoverable for users in Tell Me search and in the role explorer under Report and Analysis. 
+Available from version 23, users can view and analyze query data directly from the [!INCLUDE[prod_short](includes/prod_short.md)] client in analysis mode. The data is analyzed in real time and respects the data security that has been set up for the users. Just like for pages, you can make queries discoverable for users in Tell Me search and in the role explorer under Report and Analysis. 
 
 :::image type="content" source="/dynamics365/business-central/media/data-analysis-gl-entries.png" alt-text="Example of how to do data analysis on the G/L entries page." lightbox="/dynamics365/business-central/media/data-analysis-gl-entries.png":::
 

--- a/dev-itpro/developer/devenv-extending-best-price-calculations.md
+++ b/dev-itpro/developer/devenv-extending-best-price-calculations.md
@@ -32,7 +32,7 @@ You can have multiple setups with the same combination of method, type, and prod
 
 By default, all sales lines use the Business Central (Version 15.0) implementation to calculate prices, unless the second line has a detailed setup that defines exceptions. 
 
-The Price Calculation method on the document line searches for a setup that that has a matching combination of the method, the price type, and product type on the document line. The method then searches for detailed lines that contain exceptions for the combination of a source group (Customer, Vendor, and Job) and an product (item, resource, and so on) on the document line. If a matching setup is found its implementation is used to calculate a price. If there is no matching setup exception, we use the default implementation. 
+The Price Calculation method on the document line searches for a setup that has a matching combination of the method, the price type, and product type on the document line. The method then searches for detailed lines that contain exceptions for the combination of a source group (Customer, Vendor, and Job) and an product (item, resource, and so on) on the document line. If a matching setup is found its implementation is used to calculate a price. If there is no matching setup exception, we use the default implementation. 
 
 For example, let's say we have a line on a sales order for Customer 20000 contains item 1000. The default implementation for the sale of any asset is Business Central (Version 15.0), but the Business Central (Version 16.0) implementation contains a detailed setup line for Item 1000. That means that the Business Central (Version 16.0) implementation will calculate the price. 
 

--- a/dev-itpro/developer/devenv-howto-excel-report-layout.md
+++ b/dev-itpro/developer/devenv-howto-excel-report-layout.md
@@ -26,7 +26,7 @@ When designing an Excel layout, you need to know the following information:
 
 ### Excel layout data contract in 2023 release wave 1 and earlier versions
 
-Every Excel layout file must have a worksheet called _Data_. This worksheet has one purpose: defining which metadata fields from the the dataset definition of the report object the layout uses, which is sometimes also called the _data contract_ between the layout file and the report dataset definition. The data contract consists of the following rules:
+Every Excel layout file must have a worksheet called _Data_. This worksheet has one purpose: defining which metadata fields from the dataset definition of the report object the layout uses, which is sometimes also called the _data contract_ between the layout file and the report dataset definition. The data contract consists of the following rules:
 
 1. Metadata fields must be written in the first row of the _Data_ worksheet, one in each cell.
 1. All metadata fields in the _Data_ worksheet must exist as metadata fields in the dataset definition of the report object.

--- a/dev-itpro/developer/devenv-instrument-application-for-telemetry-app-insights.md
+++ b/dev-itpro/developer/devenv-instrument-application-for-telemetry-app-insights.md
@@ -125,7 +125,7 @@ Try to use the “Object ActionInPastTense” pattern for the Message part of a 
 
 Here are some examples from the built-in [!INCLUDE[prod_short](../developer/includes/prod_short.md)] telemetry: 
 - Web Service Called 
-- Report canceled: {report name name}
+- Report canceled: {report name}
 - Extension published: {Extension name}
 
 Consider also adding some of the dimension values into the message itself. This makes it easier to browse the events by message column alone (no need to open up custom dimensions for every single event to see, e.g.,  which page it was about). 

--- a/dev-itpro/developer/devenv-migrate-table-fields-down.md
+++ b/dev-itpro/developer/devenv-migrate-table-fields-down.md
@@ -14,7 +14,7 @@ ms.reviewer: jswymer
 This article explains how to move tables and fields from an extension to another extension that is down the dependency graph.
 
 > [!TIP]
-> For more information about the general concepts for moving tables and fields between extensions, see [Migrating Tables and Fields Between Extensions](devenv-migrate-table-fields.md). This article explains the the difference between moving up and down the dependency graph.
+> For more information about the general concepts for moving tables and fields between extensions, see [Migrating Tables and Fields Between Extensions](devenv-migrate-table-fields.md). This article explains the difference between moving up and down the dependency graph.
 
 ## Overview
 

--- a/dev-itpro/developer/devenv-migrate-table-fields-up.md
+++ b/dev-itpro/developer/devenv-migrate-table-fields-up.md
@@ -15,7 +15,7 @@ ms.custom: sfi-image-nochange
 This article explains how to move tables and fields from an extension to another extension that is up the dependency graph.
 
 > [!TIP]
-> For more information about the general concepts for moving tables and fields between extensions, see [Migrating Tables and Fields Between Extensions](devenv-migrate-table-fields.md). This article explains the the difference between moving up and down the dependency graph.
+> For more information about the general concepts for moving tables and fields between extensions, see [Migrating Tables and Fields Between Extensions](devenv-migrate-table-fields.md). This article explains the difference between moving up and down the dependency graph.
 
 ## Overview
 

--- a/dev-itpro/developer/devenv-oncompanyopencompleted.md
+++ b/dev-itpro/developer/devenv-oncompanyopencompleted.md
@@ -39,7 +39,7 @@ to:
 ```
 
 > [!NOTE]
-> Events that are emitted from within the OnCompanyOpen event will eventually be moved to the the `OnAfterLogin` event or the OnCompanyOpenCompleted event, or they'll be changed to isolated events.
+> Events that are emitted from within the OnCompanyOpen event will eventually be moved to the `OnAfterLogin` event or the OnCompanyOpenCompleted event, or they'll be changed to isolated events.
 
 ## Related information
 

--- a/dev-itpro/developer/devenv-partial-records.md
+++ b/dev-itpro/developer/devenv-partial-records.md
@@ -67,7 +67,7 @@ Notice that the call to [SetLoadFields](methods-auto/record/record-setloadfields
 This feature gives you the ability to limit the fields that load for a record to only those fields that are necessary. In general, loading fewer fields will make operations faster. But the most significant performance gains can be seen with table extensions - by not loading unnecessary fields in table extensions. Table extensions that don't have any fields for loading won't be part of the data join, which saves time.
 
 <!--
-The main goal of the feature is to provide the ability to limit the number of fields that are necessary to load. In general, loading fewer fields will make operations more performant. But the most significant performance gain  gain more importantly, limiting the set of fields needed to not load any fields from other table extensions is where the majority gain will be seen. Some of the performance issues that customers have observed with many table extensions on a base table will go away with this optimization.
+The main goal of the feature is to provide the ability to limit the number of fields that are necessary to load. In general, loading fewer fields will make operations more performant. But the most significant performance gain. More importantly, limiting the set of fields needed to not load any fields from other table extensions is where the majority gain will be seen. Some of the performance issues that customers have observed with many table extensions on a base table will go away with this optimization.
 -->
 
 > [!TIP]

--- a/dev-itpro/developer/devenv-partial-records.md
+++ b/dev-itpro/developer/devenv-partial-records.md
@@ -67,7 +67,7 @@ Notice that the call to [SetLoadFields](methods-auto/record/record-setloadfields
 This feature gives you the ability to limit the fields that load for a record to only those fields that are necessary. In general, loading fewer fields will make operations faster. But the most significant performance gains can be seen with table extensions - by not loading unnecessary fields in table extensions. Table extensions that don't have any fields for loading won't be part of the data join, which saves time.
 
 <!--
-The main goal of the feature is to provide the ability to limit the number of fields that are necessary to load. In general, loading fewer fields will make operations more performant. But the most significant performance gain. More importantly, limiting the set of fields needed to not load any fields from other table extensions is where the majority gain will be seen. Some of the performance issues that customers have observed with many table extensions on a base table will go away with this optimization.
+The main goal of the feature is to provide the ability to limit the number of fields that are necessary to load. In general, loading fewer fields will make operations more performant. More importantly, limiting the set of fields needed to not load any fields from other table extensions is where the majority gain will be seen. Some of the performance issues that customers have observed with many table extensions on a base table will go away with this optimization.
 -->
 
 > [!TIP]

--- a/dev-itpro/developer/devenv-performance-toolkit.md
+++ b/dev-itpro/developer/devenv-performance-toolkit.md
@@ -359,7 +359,7 @@ An internal PowerShell process should start and an output window appears in Visu
 ### Run using the PowerShell scripts
 
 > [!NOTE]  
-> The the Performance Toolkit extension in Visual Studio Code automatically installs these PowerShell scripts. However, if you aren't using the Performance Toolkit in Visual Studio Code, you'll need to download the scripts. The scripts are available in the [DVD](/dynamics365/business-central/dev-itpro/deployment/install-using-setup) in the **Applications\testframework\TestRunner** folder. To get there, follow these steps:
+> The Performance Toolkit extension in Visual Studio Code automatically installs these PowerShell scripts. However, if you aren't using the Performance Toolkit in Visual Studio Code, you'll need to download the scripts. The scripts are available in the [DVD](/dynamics365/business-central/dev-itpro/deployment/install-using-setup) in the **Applications\testframework\TestRunner** folder. To get there, follow these steps:
 >
 > 1. Go to [Download the files](/dynamics365/business-central/dev-itpro/deployment/install-using-setup#download-the-files).
 > 1. Choose the link to the latest version of [!INCLUDE [prod_short](../includes/prod_short.md)].

--- a/dev-itpro/developer/devenv-permissionset-composing.md
+++ b/dev-itpro/developer/devenv-permissionset-composing.md
@@ -140,7 +140,7 @@ The following table shows how the permissions are determined on a single object 
 |Permissions = tabledata Customer = RiMD<br>ExcludedPermissionSets = B|Permissions = tabledata Customer = IMD|tabledata Customer = R|
 
 > [!TIP]
-> When including and excluding multiple permission sets, it can be difficult to get an overview of what the resultant permissions will be. To help, use the **View all permissions** action from the the permission set in the client.
+> When including and excluding multiple permission sets, it can be difficult to get an overview of what the resultant permissions will be. To help, use the **View all permissions** action from the permission set in the client.
 
 ## Related information
 

--- a/dev-itpro/developer/devenv-retaining-data-after-publishing.md
+++ b/dev-itpro/developer/devenv-retaining-data-after-publishing.md
@@ -59,7 +59,7 @@ If you, during development, for example, discover that you no longer want field 
 
 - Making major table structural changes could lead to compilation errors. For example, if you want to update a primary key. In this case, the table data cannot be synchronized, and if you want to publish the extension, you must change the `schemaUpdateMode` to `Recreate`. Likewise, changing the [DataPerCompany](properties/devenv-datapercompany-property.md) from `true` to `false` and from `false` to `true` is a schema-breaking change, and therefore not allowed because it changes the number of tables per company.
 
-- For extensions built on [!INCLUDE[prod_short](includes/prod_short.md)] Spring 2019 or earlier, if a table field has the `SqlDataType` set to a value other than `Varchar` (which is the default), you must delete the `SqlDataType` property on the field, otherwise, you will will not be able to successfully synchronize the extension.
+- For extensions built on [!INCLUDE[prod_short](includes/prod_short.md)] Spring 2019 or earlier, if a table field has the `SqlDataType` set to a value other than `Varchar` (which is the default), you must delete the `SqlDataType` property on the field, otherwise, you will not be able to successfully synchronize the extension.
 
     If the `SqlDataType` property is still needed, you will have to create a new table in the extension that has the same definition as the original table, and write upgrade code that migrates the data from the original table to the new table. For more information, see [Writing upgrade code](devenv-upgrading-extensions.md#writing-upgrade-code).
 

--- a/dev-itpro/developer/devenv-translations-overview.md
+++ b/dev-itpro/developer/devenv-translations-overview.md
@@ -67,7 +67,7 @@ If the page control is based on a table field, and if no translations are found 
 
 ![Translation.](../media/Translations_2.png "Translations to display")
 
-The illustration shows examples of how translations for a page caption, a control caption, an enum caption, and a text constant are found. The search is sequential and starts at number 1, and stops searching when the the first translation is met. So, if you, for example, have an enum and no translations are found for the local language or the primary local language, the search stops at the global language because a match is found, and will use that translation in the UI.
+The illustration shows examples of how translations for a page caption, a control caption, an enum caption, and a text constant are found. The search is sequential and starts at number 1, and stops searching when the first translation is met. So, if you, for example, have an enum and no translations are found for the local language or the primary local language, the search stops at the global language because a match is found, and will use that translation in the UI.
 
 > [!NOTE]  
 > For **Enum Caption** an additional search marked with *) in the above illustration is added with [!INCLUDE[prod_short](../includes/prod_short.md)] version 18.3.


### PR DESCRIPTION
Fixes duplicate words across 14 developer documentation files: 'the the', 'that that', 'can can', 'will will', 'name name}', and a mangled sentence in partial-records ('gain  gain more importantly' corrected to 'gain. More importantly'). Also fixes 'an product' to 'a product' in devenv-extending-best-price-calculations.md.