### PR TITLE
Remove doubled words and fix typos in miscellaneous devitpro docs

### DIFF
--- a/dev-itpro/administration/administration-center-api_app_management.md
+++ b/dev-itpro/administration/administration-center-api_app_management.md
@@ -363,7 +363,7 @@ Example `400 Bad Request` response when dependent apps need to be updated first:
 { 
   "code": string, // Error Code 
   "message": string, // Detailed error message 
-  "data": { // Any additional data for the error. For example, when when "installOrUpdateNeededDependencies" in the request body was set to false, and dependencies need to be installed or updated.  
+  "data": { // Any additional data for the error. For example, when "installOrUpdateNeededDependencies" in the request body was set to false, and dependencies need to be installed or updated.  
     "requirements": [ // List of requirements you need to fulfil before you can run the request 
       { 
         "appId": guid, 

--- a/dev-itpro/administration/faq-migrate-data.md
+++ b/dev-itpro/administration/faq-migrate-data.md
@@ -133,7 +133,7 @@ To keep the Role Center experience as clean as possible and avoid permission err
 
 <!-- Not necessarily. Most extensions will run without issues in the online environment. You may want to consider uninstalling extensions that send data to an external service to avoid potential duplicated calls to that service. It's a best practice to test any extension in a sandbox tenant configured for the Business Central online environment that you're connecting to. --> 
 
-No. But if your cloud migration includes data upgrade of a large amount of data, we recommend that you uninstall the extensions that that include any data to move. It speeds up the upgrade and overall cloud migration process. You can reinstall the extensions after the migration.
+No. But if your cloud migration includes data upgrade of a large amount of data, we recommend that you uninstall the extensions that include any data to move. It speeds up the upgrade and overall cloud migration process. You can reinstall the extensions after the migration.
 
 
 <!--## How do I build an extension that enables data replication?

--- a/dev-itpro/administration/prepare-for-cookie-samesite-policy.md
+++ b/dev-itpro/administration/prepare-for-cookie-samesite-policy.md
@@ -47,7 +47,7 @@ To prevent disruption, you must upgrade the platform for your version of Dynamic
 |Dynamics NAV 2016|[49](https://support.microsoft.com/help/4528701/cumulative-update-49-for-microsoft-dynamics-nav-2016-build-51640)|
 |Dynamics NAV 2017|[36](https://support.microsoft.com/help/4528702/cumulative-update-36-for-microsoft-dynamics-nav-2017-build-30074)|
 |Dynamics NAV 2018|[23](https://support.microsoft.com/help/4528703/cumulative-update-23-for-microsoft-dynamics-nav-2018-build-37606)|
-|Dynamics 365 365 Business Central Fall 2018|[13](https://support.microsoft.com/help/4528704/cumulative-update-13-for-microsoft-dynamics-365-business-central-on-pr)|
+|Dynamics 365 Business Central Fall 2018|[13](https://support.microsoft.com/help/4528704/cumulative-update-13-for-microsoft-dynamics-365-business-central-on-pr)|
 |Dynamics 365 Business Central Spring 2019|[06](https://support.microsoft.com/help/4528705/cumulative-update-06-for-microsoft-dynamics-365-business-central-sprin)|
 |Dynamics 365 Business Central 2019 Release Wave 2|[15.2](https://support.microsoft.com/help/4533389/update-15-1-for-microsoft-dynamics-365-business-central-2019-release-w)|
 

--- a/dev-itpro/api-reference/v1.0/resources/dynamics_salesquote.md
+++ b/dev-itpro/api-reference/v1.0/resources/dynamics_salesquote.md
@@ -65,7 +65,7 @@ Represents a salesQuote resource type in [!INCLUDE[prod_short](../../../includes
 |totalTaxAmount|numeric|The total tax amount for the quote. Read-Only.|
 |totalAmountIncludingTax|numeric|The total amount for the quote, including tax. Read-Only.|
 |status|string, maximum size 20|The quote status. Status can be: Draft,Sent,Accepted. Read-Only.|
-|sentDate|datetime|The the date and time the quote was sent our to the customer. Read-Only.|
+|sentDate|datetime|The date and time the quote was sent out to the customer. Read-Only.|
 |validUntilDate|Date|The date a quote is valid until.|
 |acceptedDate|Date|The date a quote is accepted. Read-Only.|
 |billToName             |string, maximum length 100   |The name of the customer to bill.|

--- a/dev-itpro/deployment/Deploying-dynamics-nav-client-clickonce.md
+++ b/dev-itpro/deployment/Deploying-dynamics-nav-client-clickonce.md
@@ -68,7 +68,7 @@ The [!INCLUDE[nav_windows_short](../developer/includes/nav_windows_short.md)] re
 
    The ClickOnce online installation web page includes a link to download .NET Framework. However, using this option requires that users have administrative rights on their computers. 
 
-2. An administrator install install .NET Framework on users computers. 
+2. An administrator install .NET Framework on users' computers. 
 
    For more information about how to install .NET Framework, see [Install the .NET Framework for developers](https://go.microsoft.com/fwlink/?LinkId=272382).   
 

--- a/dev-itpro/includes/cloud-migration-sql-connection-ir.md
+++ b/dev-itpro/includes/cloud-migration-sql-connection-ir.md
@@ -11,7 +11,7 @@ If the product you selected requires an SQL connection, the **Define your SQL da
 
 - **SQL connection**
 
-  Specify **SQL Server** if the database is installed locally on an SQL Server instance. Specify **Azure SQL** if the database is an Azure SQL Database database.
+  Specify **SQL Server** if the database is installed locally on an SQL Server instance. Specify **Azure SQL** if the database is an Azure SQL Database.
  
 <!-- 
   > [!IMPORTANT]


### PR DESCRIPTION
Fixes across six files: 'when when' in admin-center-api app management, 'that that' in faq-migrate-data, '365 365' in cookie samesite policy, 'Database database' in cloud-migration SQL include, 'install install' and 'users computers' (missing apostrophe) in ClickOnce deployment, and 'The the'/'sent our' (should be 'sent out') in salesquote API reference.