### PR TITLE
Add namespace and using directives to AL code examples in business events and interfaces documentation

### DIFF
--- a/dev-itpro/developer/business-events-overview.md
+++ b/dev-itpro/developer/business-events-overview.md
@@ -176,31 +176,36 @@ To build and install an extension that implements custom business events, see ou
 1. Use the **Business Central Virtual Data Source Configuration** table to refresh the Business Central catalog with custom business events on your Dataverse environment (see [previous section](#refresh-business-central-catalog-of-business-events)).
 
 ```al
+namespace MyCompany.SalesExtension;
+
+using System.Integration;
+using Microsoft.Sales.Document;
+
 enumextension 50101 MyEnumExtension extends EventCategory
 {
-   value(0; "Sales")
-   {
-   }
+   value(0; "Sales")
+   {
+   }
 }
 
-codeunit 50102 MyCodeunit 
-{ 
-   trigger OnRun()
+codeunit 50102 MyCodeunit 
+{ 
+   trigger OnRun()
    begin
-   end; 
+   end; 
 
    [ExternalBusinessEvent('salesorderposted', 'Sales order posted', 'Triggered when sales order has been posted', EventCategory::"Sales")]
    [RequiredPermissions(PermissionObjectType::TableData, Database::"Sales Header", 'R')] // optional
-   procedure SalesOrderPosted(salesOrderId: Guid; customerName: Text; orderNumber: Text)
-   begin
-   end;
-   
-   [EventSubscriber(ObjectType::Page, Page::"Sales Order", 'OnPostDocumentBeforeNavigateAfterPosting', '', true, true)] 
-   local procedure OnPostDocument(var SalesHeader: Record "Sales Header"; var PostingCodeunitID: Integer; var Navigate: Enum "Navigate After Posting"; DocumentIsPosted: Boolean; var IsHandled: Boolean) 
+   procedure SalesOrderPosted(salesOrderId: Guid; customerName: Text; orderNumber: Text)
    begin
-      SalesOrderPosted(SalesHeader.SystemId, SalesHeader."Sell-to Customer Name", SalesHeader."No."); 
    end;
-} 
+   
+   [EventSubscriber(ObjectType::Page, Page::"Sales Order", 'OnPostDocumentBeforeNavigateAfterPosting', '', true, true)] 
+   local procedure OnPostDocument(var SalesHeader: Record "Sales Header"; var PostingCodeunitID: Integer; var Navigate: Enum "Navigate After Posting"; DocumentIsPosted: Boolean; var IsHandled: Boolean) 
+   begin
+      SalesOrderPosted(SalesHeader.SystemId, SalesHeader."Sell-to Customer Name", SalesHeader."No."); 
+   end;
+} 
 ```
 
 ## Query Business Central catalog of business events in non-Dataverse systems

--- a/dev-itpro/developer/devenv-interfaces-in-al.md
+++ b/dev-itpro/developer/devenv-interfaces-in-al.md
@@ -64,6 +64,8 @@ The following example defines an interface `IAddressProvider`, which has one met
 The `MyAddressPage` is a simple page with an action that captures the choice of address and calls, based on that choice, an implementation of the `IAddressProvider` interface.
 
 ```AL
+namespace MyCompany.AddressManagement;
+
 interface "IAddressProvider"
 {
     procedure GetAddress(): Text
@@ -183,6 +185,10 @@ The [Dictionary](methods-auto/dictionary/dictionary-data-type.md) and [List](met
 The following example illustrates how to create a [Dictionary](methods-auto/dictionary/dictionary-data-type.md) of interfaces:
 
 ```AL
+namespace MyCompany.BarcodeExamples;
+
+using System.Text;
+
 codeunit 50120 MyDictionaryCodeunit
 {
     procedure MyProcedure(): Dictionary of [Integer, Interface "Barcode Font Provider"]
@@ -199,6 +205,8 @@ codeunit 50120 MyDictionaryCodeunit
 The following example illustrates how to create a [List](methods-auto/list/list-data-type.md) of interfaces:
 
 ```al
+namespace MyCompany.ShapeExamples;
+
 interface IShape
 {
     procedure GetArea(): Decimal;


### PR DESCRIPTION
AL code examples in two developer articles were missing namespace declarations and using directives required from BC22 (runtime 11.0+). Fixes business-events-overview.md and devenv-interfaces-in-al.md. Namespaces verified against BCApps: System.Text for Barcode Font Provider, System.Integration for EventCategory, Microsoft.Sales.Document for Sales Header.