### PR TITLE
Replace stale C/AL references with AL in deployment and security docs

### DIFF
--- a/dev-itpro/deployment/Multitenant-Deployment-Architecture.md
+++ b/dev-itpro/deployment/Multitenant-Deployment-Architecture.md
@@ -60,7 +60,7 @@ author: jswymer
  If you have an existing [!INCLUDE[prod_short](../developer/includes/prod_short.md)] application that you want to use in a multitenant deployment, there are a number of changes that you have to make. This includes setting up the permission sets in a way that supports all tenants that use that application.  
   
 ### URLs and Tenants  
- In multitenant deployments, URLs must specify the tenant that the URL applies to. If you have C/AL code that constructs URLs, you must update the code to include the tenant. Alternatively, update your code with the [GETURL Function](../developer/methods-auto/library.md) to get the URLs calculated for you. The same applies to hyperlinks in report objects, for example.  
+ In multitenant deployments, URLs must specify the tenant that the URL applies to. If you have AL code that constructs URLs, you must update the code to include the tenant. Alternatively, update your code with the [GETURL Function](../developer/methods-auto/library.md) to get the URLs calculated for you. The same applies to hyperlinks in report objects, for example.  
   
  The URL can specify the tenant ID or the tenant host name if you specify host names as alternative IDs for tenants. For example, the following URL consumes the **Customer** ODATA web service for a specific tenant:  
   

--- a/dev-itpro/security/security-lock-down-server-communication.md
+++ b/dev-itpro/security/security-lock-down-server-communication.md
@@ -38,7 +38,7 @@ The [!INCLUDE[prod_short](../developer/includes/prod_short.md)] instance include
 |ClientServicesMaxUploadSize​|30MB|Helps to avoid out-of-memory errors.|
 |RestrictedFileTypes​ (ClientServicesProhibitedFileTypes)||Prevents specific file types from uploaded to the database from the client. |
 |EnableDataExportImport​|||
-|EnableALServerFileAccess​|true|Specifies whether access to server files by C/AL file data type functions is allowed.|
+|EnableALServerFileAccess​|true|Specifies whether access to server files by AL file data type functions is allowed.|
 |DebuggingAllowed​|true|Specifies whether AL debugging is allowed for this [!INCLUDE[server](../developer/includes/server.md)] instance.|
 |EnableDebugging|false| With the EnableDebugging flag set to true the Microsoft Dynamics NAV Server will start with debugging mode enabled.  This mode has three main functions:1)Upon first connection by a RoleTailored Client all C# for that application will be generated. 2) C# files will be persisted between server restarts. 3)  Application Objects will be compiled with debug information.|
 


### PR DESCRIPTION
Two non-migration docs still use the old C/AL terminology.

**Multitenant-Deployment-Architecture.md** (line 63):
> 'If you have **C/AL** code that constructs URLs' -> 'If you have **AL** code'

This is an architectural guidance doc targeting current AL developers, not a C/AL migration guide.

**security-lock-down-server-communication.md** (line 41):
The `EnableALServerFileAccess` server setting (already named with 'AL') has a description that still says '**C/AL** file data type functions'. Updated to 'AL file data type functions' for consistency with the setting name.

Verified against:
- `BCApps` repo confirms AL is the current extension language
- Setting name `EnableALServerFileAccess` in server config confirms 'AL' is the correct term