### PR TITLE
Correct Shopify event subscriber signatures in extensibility code examples

### DIFF
--- a/dev-itpro/developer/devenv-extending-shopify.md
+++ b/dev-itpro/developer/devenv-extending-shopify.md
@@ -527,7 +527,7 @@ The following example shows how to implement logic for defining prices.
 codeunit 50105 "Shpfy Custom Price"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Product Events", OnBeforeCalculateUnitPrice, '', false, false)]
-    procedure BeforeCalculateUnitPrice(Item: Record Item; VariantCode: Code[20]; UnitOfMeasure: Code[20]; ShopifyShop: Record "Shpfy Shop"; var UnitCost: Decimal; var Price: Decimal; var ComparePrice: Decimal; var Handled: Boolean)
+    procedure BeforeCalculateUnitPrice(Item: Record Item; VariantCode: Code[20]; UnitOfMeasure: Code[20]; ShopifyShop: Record "Shpfy Shop"; Catalog: Record "Shpfy Catalog"; var UnitCost: Decimal; var Price: Decimal; var ComparePrice: Decimal; var Handled: Boolean)
     var
         CurrExchRate: Record "Currency Exchange Rate";
         ItemUOM: Record "Item Unit of Measure";
@@ -556,7 +556,7 @@ The following example shows how to implement logic for defining compare-at price
 codeunit 50110 "Shpfy Custom Compare Price"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Product Events", OnAfterCalculateUnitPrice, '', false, false)]
-    procedure AfterCalculateUnitPrice(Item: Record Item; VariantCode: Code[20]; UnitOfMeasure: Code[20]; ShopifyShop: Record "Shpfy Shop"; var UnitCost: Decimal; var Price: Decimal; var ComparePrice: Decimal)
+    procedure AfterCalculateUnitPrice(Item: Record Item; VariantCode: Code[20]; UnitOfMeasure: Code[20]; ShopifyShop: Record "Shpfy Shop"; Catalog: Record "Shpfy Catalog"; var UnitCost: Decimal; var Price: Decimal; var ComparePrice: Decimal)
     begin
         ComparePrice := Round(Price * 1.3, 1);
         Price := Round(Price, 1) - 0.05;

--- a/dev-itpro/developer/devenv-extending-shopify.md
+++ b/dev-itpro/developer/devenv-extending-shopify.md
@@ -92,7 +92,7 @@ Now you can publish the updated connector and connect [!INCLUDE [prod_short](../
 
 ### Known issues with authentication
 
-#### Error: Oauth error invalid_request: The redirect_uri is not whitelisted.
+#### Error: Oauth error invalid_request: The redirect_uri is not allowlisted.
 
 Make sure that you filled in the **Allowed redirection URL(s)** field correctly in the **Configuration** section.
 

--- a/dev-itpro/developer/devenv-extending-shopify.md
+++ b/dev-itpro/developer/devenv-extending-shopify.md
@@ -92,7 +92,7 @@ Now you can publish the updated connector and connect [!INCLUDE [prod_short](../
 
 ### Known issues with authentication
 
-#### Error: Oauth error invalid_request: The redirect_uri is not allowlisted.
+#### Error: Oauth error invalid_request: The redirect_uri is not whitelisted.
 
 Make sure that you filled in the **Allowed redirection URL(s)** field correctly in the **Configuration** section.
 

--- a/dev-itpro/developer/devenv-extending-shopify.md
+++ b/dev-itpro/developer/devenv-extending-shopify.md
@@ -195,7 +195,7 @@ The following example shows how to check whether a Shopify order is ready to be 
 codeunit 50107 "Shpfy Order Check Pay. Method"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Shpfy Order Events", OnBeforeCreateSalesHeader, '', false, false)]
-    internal procedure OnBeforeCreateSalesHeader(ShopifyOrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header"; var Handled: Boolean)
+    internal procedure OnBeforeCreateSalesHeader(ShopifyOrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header"; var LastCreatedDocumentId: Guid; var Handled: Boolean)
     begin
         ShopifyOrderHeader.Testfield("Payment Method Code");
     end;


### PR DESCRIPTION
Three event subscriber signatures in the code examples for devenv-extending-shopify.md did not match the actual integration event signatures in the connector. Developers copying these examples would get compile errors.

**Fix 1: OnBeforeCreateSalesHeader missing LastCreatedDocumentId**

Doc had:

  procedure OnBeforeCreateSalesHeader(ShopifyOrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header"; var Handled: Boolean)

Actual event in ShpfyOrderEvents.Codeunit.al (CU 30162):

  procedure OnBeforeCreateSalesHeader(ShopifyOrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header"; var LastCreatedDocumentId: Guid; var Handled: Boolean)

Note: Subscribers that set Handled to true and create the Sales Header themselves must also set LastCreatedDocumentId so cleanup works correctly on failure.

**Fix 2: OnBeforeCalculateUnitPrice missing Catalog parameter**

Doc had:

  procedure BeforeCalculateUnitPrice(...; ShopifyShop: Record "Shpfy Shop"; var UnitCost: Decimal; ...)

Actual event in ShpfyProductEvents.Codeunit.al:

  procedure OnBeforeCalculateUnitPrice(...; ShopifyShop: Record "Shpfy Shop"; Catalog: Record "Shpfy Catalog"; var UnitCost: Decimal; ...)

**Fix 3: OnAfterCalculateUnitPrice missing Catalog parameter**

Doc had:

  procedure AfterCalculateUnitPrice(...; ShopifyShop: Record "Shpfy Shop"; var UnitCost: Decimal; ...)

Actual event in ShpfyProductEvents.Codeunit.al:

  procedure OnAfterCalculateUnitPrice(...; ShopifyShop: Record "Shpfy Shop"; Catalog: Record "Shpfy Catalog"; var UnitCost: Decimal; ...)

The Catalog parameter was added when B2B catalog-specific pricing was introduced and the events were updated, but the doc examples were not.

**Verified against**

BCApps: src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyOrderEvents.Codeunit.al

BCApps: src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
