### PR TITLE
Add PR labeler workflow for auto-classifying external PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,221 @@
+name: "PR Labeler"
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label-pr:
+    # Only run on the public repo — prevents execution if synced to private
+    if: github.repository == 'MicrosoftDocs/dynamics365smb-devitpro-pb'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        run: |
+          # Get the list of changed files in the PR
+          git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+          echo "Changed files:"
+          cat changed_files.txt
+
+      - name: Analyze PR and assign labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+
+            const changedFiles = fs.readFileSync('changed_files.txt', 'utf8')
+              .split('\n')
+              .filter(f => f.trim().length > 0);
+
+            const labels = new Set();
+
+            // --- Path-based labels ---
+            const pathRules = [
+              { pattern: /^properties\//, label: 'reference-docs' },
+              { pattern: /^triggers\//, label: 'reference-docs' },
+              { pattern: /^dev-itpro\/.*\/analyzers\//, label: 'reference-docs' },
+              { pattern: /^dev-itpro\/.*\/attributes\//, label: 'reference-docs' },
+              { pattern: /^dev-itpro\/.*\/methods-auto\//, label: 'reference-docs' },
+              { pattern: /^dev-itpro\/.*\/triggers-auto\//, label: 'reference-docs' },
+              { pattern: /^dev-itpro\/.*\/api\//, label: 'api' },
+              { pattern: /^onprem\//, label: 'on-prem' },
+              { pattern: /^dev-itpro\/upgrade\//, label: 'upgrade' },
+              { pattern: /^dev-itpro\/administration\//, label: 'administration' },
+              { pattern: /^dev-itpro\/developer\//, label: 'developer' },
+              { pattern: /^dev-itpro\/security\//, label: 'security' },
+            ];
+
+            for (const file of changedFiles) {
+              for (const rule of pathRules) {
+                if (rule.pattern.test(file)) {
+                  labels.add(rule.label);
+                }
+              }
+            }
+
+            // --- Content-based analysis ---
+            let totalAdditions = 0;
+            let totalDeletions = 0;
+            let hasCodeChanges = false;
+            let hasDoNotEditChanges = false;
+            let isTypoOnly = true;
+
+            // Get the full diff
+            const diff = execSync(
+              `git diff origin/${process.env.BASE_REF}...HEAD`,
+              { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
+            );
+
+            // Parse diff by file
+            const fileDiffs = diff.split(/^diff --git /m).filter(d => d.length > 0);
+
+            for (const fileDiff of fileDiffs) {
+              const lines = fileDiff.split('\n');
+
+              // Check if changes are inside DO_NOT_EDIT blocks
+              // We look at the full file content for changed files
+              const fileMatch = fileDiff.match(/^a\/(.+?) b\//);
+              if (!fileMatch) continue;
+              const filePath = fileMatch[1];
+
+              // Only analyze markdown files
+              if (!filePath.endsWith('.md')) continue;
+
+              // Count additions and deletions (lines starting with + or - after the header)
+              let inHunk = false;
+              let addedLines = [];
+              let removedLines = [];
+
+              for (const line of lines) {
+                if (line.startsWith('@@')) {
+                  inHunk = true;
+                  continue;
+                }
+                if (!inHunk) continue;
+
+                if (line.startsWith('+') && !line.startsWith('+++')) {
+                  addedLines.push(line.substring(1));
+                  totalAdditions++;
+                } else if (line.startsWith('-') && !line.startsWith('---')) {
+                  removedLines.push(line.substring(1));
+                  totalDeletions++;
+                }
+              }
+
+              // Check for code block changes (fenced code in AL, json, xml, etc.)
+              const codeBlockPattern = /^```\s*(al|json|xml|yaml|powershell|csharp|cs|javascript|js)/i;
+              let inCodeBlock = false;
+
+              for (const line of addedLines.concat(removedLines)) {
+                if (codeBlockPattern.test(line.trim())) {
+                  inCodeBlock = !inCodeBlock;
+                  continue;
+                }
+                // If a changed line is inside a code fence, or looks like AL/code
+                if (line.match(/^\s*(trigger|procedure|local|var|begin|end;|if |then|else|exit\(|record\s|codeunit\s|page\s|table\s)/i)) {
+                  hasCodeChanges = true;
+                }
+              }
+
+              // Check for inline code additions (full code blocks added/modified)
+              const allChangedText = addedLines.concat(removedLines).join('\n');
+              if (allChangedText.match(/```(al|json|xml|yaml|powershell|csharp)/i)) {
+                hasCodeChanges = true;
+              }
+
+              // Check if changes touch DO_NOT_EDIT sections
+              if (fs.existsSync(filePath)) {
+                const content = fs.readFileSync(filePath, 'utf8');
+                const doNotEditPattern = /(START>DO_NOT_EDIT)([\s\S]*?)(END>DO_NOT_EDIT)/g;
+                let match;
+                while ((match = doNotEditPattern.exec(content)) !== null) {
+                  // Check if any added/removed line appears within a DO_NOT_EDIT block
+                  const blockContent = match[0];
+                  for (const changed of addedLines) {
+                    if (changed.trim().length > 0 && blockContent.includes(changed.trim())) {
+                      hasDoNotEditChanges = true;
+                      break;
+                    }
+                  }
+                }
+              }
+
+              // Typo detection: large structural changes are not typos
+              for (const added of addedLines) {
+                // If any added line is more than a small text change, it's not a typo
+                if (added.trim().startsWith('#') || added.trim().startsWith('```') ||
+                    added.trim().length > 200) {
+                  isTypoOnly = false;
+                }
+              }
+            }
+
+            // Heuristic: typo-only if total changes are small and no code/structural changes
+            const totalChanges = totalAdditions + totalDeletions;
+            if (totalChanges > 50 || hasCodeChanges) {
+              isTypoOnly = false;
+            }
+            // A PR with 0 changes isn't a typo either
+            if (totalChanges === 0) {
+              isTypoOnly = false;
+            }
+
+            // --- Apply content-based labels ---
+            if (hasCodeChanges) {
+              labels.add('contains-code');
+            }
+            if (hasDoNotEditChanges) {
+              labels.add('edits-auto-generated');
+            }
+            if (isTypoOnly && !hasDoNotEditChanges && !hasCodeChanges) {
+              labels.add('typo-fix');
+            }
+
+            // --- Set labels on the PR ---
+            if (labels.size > 0) {
+              const labelsArray = [...labels];
+              console.log(`Applying labels: ${labelsArray.join(', ')}`);
+
+              // Ensure labels exist (create if they don't)
+              for (const label of labelsArray) {
+                try {
+                  await github.rest.issues.getLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label,
+                  });
+                } catch (e) {
+                  if (e.status === 404) {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: label,
+                      color: 'ededed',
+                    });
+                  }
+                }
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labelsArray,
+              });
+            } else {
+              console.log('No labels to apply.');
+            }
+        env:
+          BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
Labels PRs based on:
- File paths (reference-docs, api, on-prem, etc.)
- Content analysis (typo-fix, contains-code, edits-auto-generated)
- Only runs on public repo (guarded by repository condition)