### PR TITLE
Fix pr-labeler for fork PRs (pull_request_target)

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: "PR Labeler"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
@@ -14,16 +14,21 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          # Fetch the PR head so we can diff against the base
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Get changed files
         id: changed
         run: |
           # Get the list of changed files in the PR
-          git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+          git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.sha }} > changed_files.txt
           echo "Changed files:"
           cat changed_files.txt
 
@@ -74,7 +79,7 @@ jobs:
 
             // Get the full diff
             const diff = execSync(
-              `git diff origin/${process.env.BASE_REF}...HEAD`,
+              `git diff origin/${process.env.BASE_REF}...${process.env.HEAD_SHA}`,
               { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
             );
 
@@ -251,4 +256,5 @@ jobs:
               }
             }
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Problem

The \label-pr\ workflow fails on PRs from forks (#3579) with:

\\\
Resource not accessible by integration (403)
\\\

This happens because \pull_request\ events only get a read-only \GITHUB_TOKEN\ for fork PRs, regardless of declared permissions.

## Fix

- Switch trigger from \pull_request\ to \pull_request_target\ (runs in base repo context → write access)
- Explicitly checkout the PR head SHA (since \pull_request_target\ defaults to the base branch)
- Fetch base branch and diff using explicit refs

## Security note

\pull_request_target\ is safe here because we only read file content from the PR (no execution of PR-supplied code). The workflow script is always from the base branch.