### PR TITLE
Remove duplicated 'not' from upgrade task callout text

### DIFF
--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v17.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v17.md
@@ -140,7 +140,7 @@ The only file in the extension project that is required is an app.json. You can 
 4.  Build and compile the extension package. To build the extension package, select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 14**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 14**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 3: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v18.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v18.md
@@ -146,7 +146,7 @@ The only file in the extension project that is required is an app.json. You can 
 4. Build and compile the extension package. To build the extension package, select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 14**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 14**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v19.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v19.md
@@ -151,7 +151,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v20.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v20.md
@@ -150,7 +150,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v21.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v21.md
@@ -150,7 +150,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v22.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v22.md
@@ -150,7 +150,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, press Ctrl+Shift+B.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v23.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v23.md
@@ -150,7 +150,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, press Ctrl+Shift+B.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v24.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v24.md
@@ -164,7 +164,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, press Ctrl+Shift+B.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v25.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app-v25.md
@@ -171,7 +171,7 @@ The only file in the extension project that's required is an app.json. You can c
 4. Build and compile the extension package. To build the extension package, press Ctrl+Shift+B.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in **Task 17**. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 5: Create table migration extension
 

--- a/dev-itpro/upgrade/upgrade-to-microsoft-base-app.md
+++ b/dev-itpro/upgrade/upgrade-to-microsoft-base-app.md
@@ -128,7 +128,7 @@ The only file in the extension project that is required is an app.json. You can 
 4.  Build and compile the extension package. To build the extension package, select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.
 
 > [!TIP]
-> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in Task 15. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not not include upgrade code.
+> This step is only required if you need to trigger a data upgrade on these extensions, which you'll do by running Start-NavAppDataUpgrade on these extensions in Task 15. For the scenario in this article, at a minimum this step is required for the System and Base Applications. You can skip this step for any customization extensions that do not include upgrade code.
 
 ## Task 3: Create table migration extension
 


### PR DESCRIPTION
Ten upgrade guide files (v17 through v25 plus the base upgrade-to-microsoft-base-app.md) all contain the same copy-pasted callout text with a duplicated word:

> You can skip this step for any customization extensions that do not not include upgrade code.

The second 'not' makes the sentence a double negation, inverting the intended meaning. This removes the extra 'not' from all ten files, restoring the correct meaning.

Files changed: upgrade-to-microsoft-base-app-v17.md through v25.md and upgrade-to-microsoft-base-app.md.
