### PR TITLE
Correct 'occured' to 'occurred' in test method return value descriptions

### DIFF
--- a/dev-itpro/developer/methods-auto/testpage/testpage-getvalidationerror-method.md
+++ b/dev-itpro/developer/methods-auto/testpage/testpage-getvalidationerror-method.md
@@ -33,7 +33,7 @@ The index of the validation error that occurred on the test page.
 ## Return Value
 *Error*  
 &emsp;Type: [Text](../text/text-data-type.md)  
-A string where each line represents a validation error that occured on the test page.
+A string where each line represents a validation error that occurred on the test page.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)

--- a/dev-itpro/developer/methods-auto/testpart/testpart-getvalidationerror-method.md
+++ b/dev-itpro/developer/methods-auto/testpart/testpart-getvalidationerror-method.md
@@ -33,7 +33,7 @@ The index of the validation error that occurred on the test page.
 ## Return Value
 *Error*  
 &emsp;Type: [Text](../text/text-data-type.md)  
-A string where each line represents a validation error that occured on the test page.
+A string where each line represents a validation error that occurred on the test page.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)

--- a/dev-itpro/developer/methods-auto/testpart/testpart-validationerrorcount-method.md
+++ b/dev-itpro/developer/methods-auto/testpart/testpart-validationerrorcount-method.md
@@ -28,7 +28,7 @@ An instance of the [TestPart](testpart-data-type.md) data type.
 ## Return Value
 *Count*  
 &emsp;Type: [Integer](../integer/integer-data-type.md)  
-Number of validation errors that occured on the test page.
+Number of validation errors that occurred on the test page.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)


### PR DESCRIPTION
Three test method docs use 'occured' (missing the double 'r') in their return value descriptions:

- TestPage.GetValidationError: "validation error that occured on the test page"
- TestPart.GetValidationError: "validation error that occured on the test page"
- TestPart.ValidationErrorCount: "validation errors that occured on the test page"

All three corrected to 'occurred'.
