### PR TITLE
Add al language tag to Clear example code fences in JSON method docs

### DIFF
--- a/dev-itpro/developer/methods-auto/jsonarray/jsonarray-readfrom-instream-method.md
+++ b/dev-itpro/developer/methods-auto/jsonarray/jsonarray-readfrom-instream-method.md
@@ -43,7 +43,7 @@ This method can fail if the stream is in an invalid state or if the JSON data is
 If the operation succeeds, the JsonArray will be disconnected from its current JSON tree and the data contained by the JsonArray will be replaced with the new value.
 To delete the contents in a JsonArray variable use the Clear function.
 
-```
+```al
 Clear(JsonArray)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsonarray/jsonarray-readfrom-string-method.md
+++ b/dev-itpro/developer/methods-auto/jsonarray/jsonarray-readfrom-string-method.md
@@ -41,7 +41,7 @@ The String object from which the JSON data will be read.
 ## Remarks
 This method can fail if the JSON data is malformed. If the operation succeeds, the JsonArray will be disconnected from its current JSON tree and the data contained by the JsonArray will be replaced with the new value. To delete the contents in a JsonArray variable use the Clear function.
 
-```
+```al
 Clear(JsonArray)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsonobject/jsonobject-readfrom-instream-method.md
+++ b/dev-itpro/developer/methods-auto/jsonobject/jsonobject-readfrom-instream-method.md
@@ -43,7 +43,7 @@ This method can fail if the stream is in an invalid state or if the JSON data is
 If the operation succeeds, the JsonObject will be disconnected from its current JSON tree and the data contained by the JsonObject will be replaced with the new value.
 To delete the contents in a JsonObject variable use the Clear function.
 
-```
+```al
 Clear(JsonObject)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsonobject/jsonobject-readfrom-string-method.md
+++ b/dev-itpro/developer/methods-auto/jsonobject/jsonobject-readfrom-string-method.md
@@ -43,7 +43,7 @@ This method can fail if the JSON data is malformed.
 If the operation succeeds, the JsonObject will be disconnected from its current JSON tree and the data contained by the JsonObject will be replaced with the new value.
 To delete the contents in a JsonObject variable use the Clear function.
 
-```
+```al
 Clear(JsonObject)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsontoken/jsontoken-readfrom-instream-method.md
+++ b/dev-itpro/developer/methods-auto/jsontoken/jsontoken-readfrom-instream-method.md
@@ -43,7 +43,7 @@ This method can fail if the stream is in an invalid state or if the JSON data is
 If the operation succeeds, the JsonToken will be disconnected from its current JSON tree and the data contained by the JsonToken will be replaced with the new value.
 To delete the contents in a JsonToken variable use the Clear function.
 
-```
+```al
 Clear(JsonToken)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsontoken/jsontoken-readfrom-string-method.md
+++ b/dev-itpro/developer/methods-auto/jsontoken/jsontoken-readfrom-string-method.md
@@ -43,7 +43,7 @@ This method can fail if the JSON data is malformed.
 If the operation succeeds, the JsonToken will be disconnected from its current JSON tree and the data contained by the JsonToken will be replaced with the new value.
 To delete the contents in a JsonToken variable use the Clear function.
 
-```
+```al
 Clear(JsonToken)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsonvalue/jsonvalue-readfrom-instream-method.md
+++ b/dev-itpro/developer/methods-auto/jsonvalue/jsonvalue-readfrom-instream-method.md
@@ -43,7 +43,7 @@ This method can fail if the stream is in an invalid state or if the JSON data is
 If the operation succeeds, the JsonValue will be disconnected from its current JSON tree and the data contained by the JsonValue will be replaced with the new value.
 To delete the contents in a JsonValue variable use the Clear function.
 
-```
+```al
 Clear(JsonValue)
 ```
 

--- a/dev-itpro/developer/methods-auto/jsonvalue/jsonvalue-readfrom-string-method.md
+++ b/dev-itpro/developer/methods-auto/jsonvalue/jsonvalue-readfrom-string-method.md
@@ -43,7 +43,7 @@ This method can fail if the JSON data is malformed.
 If the operation succeeds, the JsonValue will be disconnected from its current JSON tree and the data contained by the JsonValue will be replaced with the new value.
 To delete the contents in a JsonValue variable use the Clear function.
 
-```
+```al
 Clear(JsonValue)
 ```
 


### PR DESCRIPTION
Eight JSON method reference docs (JsonArray, JsonObject, JsonToken, JsonValue ReadFrom variants) each contain a Remarks code block with a bare triple-backtick fence wrapping an AL Clear() call:

    `
    Clear(JsonArray)
    `

Without the language tag, the renderer treats the block as plain text and applies no syntax highlighting. Added the al tag to all eight opening fences.

Files changed:
- jsonarray-readfrom-instream-method.md
- jsonarray-readfrom-string-method.md
- jsonobject-readfrom-instream-method.md
- jsonobject-readfrom-string-method.md
- jsontoken-readfrom-instream-method.md
- jsontoken-readfrom-string-method.md
- jsonvalue-readfrom-instream-method.md
- jsonvalue-readfrom-string-method.md
