### PR TITLE
Add language tags to bare code fences in devenv developer docs

### DIFF
--- a/dev-itpro/developer/devenv-dotnet-controladdins.md
+++ b/dev-itpro/developer/devenv-dotnet-controladdins.md
@@ -23,7 +23,7 @@ The name of the assembly can be retrieved from the AssemblyName element in the `
 
 The following code sample contains the stub definition of the `Microsoft.Dynamics.Nav.Client.PingPong` .NET add-in.
  
-```
+```csharp
 namespace Microsoft.Dynamics.Nav.Client.PingPong 
 { 
 
@@ -67,7 +67,7 @@ The `ControlAddInExport` attribute's constructor takes as an argument the name o
 
  Remember to add the setting **"AL: Assembly Probing Paths"** in the **User Settings** or **Workspace Settings** specifying the path of the folder containing the assembly so that the compiler can access it. For more information, see [Getting started with Microsoft .NET Interoperability from AL](devenv-get-started-call-dotnet-from-al.md).
 
-```
+```al
 dotnet
 {
     assembly("Microsoft.Dynamics.Nav.Client.PingPong")

--- a/dev-itpro/developer/devenv-extending-best-price-calculations.md
+++ b/dev-itpro/developer/devenv-extending-best-price-calculations.md
@@ -470,7 +470,7 @@ The **Price Asset Type** enum implements the **Price Asset** interface. Add a **
     - FillFromBuffer(),
     - FillAdditionalFields()
 ```
-```
+```al
 codeunit 50002 "Price Asset - Fixed Asset" implements "Price Asset"
 {
     var

--- a/dev-itpro/developer/devenv-role-customization.md
+++ b/dev-itpro/developer/devenv-role-customization.md
@@ -60,7 +60,7 @@ However, you can export user-defined profiles and page customizations from the c
 
 Profiles that are created in the client are indicated as **\(user-created\)**. Each user-created profile is exported to a separate .al file that contains the `profile` object that defines the profile and the page customizations it uses. For example, you created a profile with the ID **MyProfile** that uses the role center page **9022 Business Manager Role Center**, and you customized the Business Manager Role Center itself, plus the **Customer** list page. The exported zip file would contain file called **PROFILE.MyProfile.al** that includes the following code:
 
-```
+```al
 profile MyProfile
 {
   CaptionML = ENU='My Profile';
@@ -76,7 +76,7 @@ profile MyProfile
 
 Page customizations that are made to user-created profiles are exported to an .al files that include a `pagecustomization` object that defines the modification to the page. A separate file is created for each customized page. Referring to the example above, the zip file would include two files: **PageCustomization._Business Manager Role Center_.Configuration1.al** and **PageCustomization._Customer List_.Configuration2.al**. The files include code similar to the following:
 
-```
+```al
 pagecustomization Configuration1 customizes "Business Manager Role Center"
 {
   layout
@@ -94,7 +94,7 @@ pagecustomization Configuration1 customizes "Business Manager Role Center"
 
 And:
 
-```
+```al
 pagecustomization Configuration2 customizes "Customer List"
 {
   layout
@@ -114,7 +114,7 @@ pagecustomization Configuration2 customizes "Customer List"
 
 Page customizations that are made to extension-based profiles are exported to two types of .al files. The first file includes a `profileextension` object that specifies which profile has been modified and includes references to the page customization object files. The second file type includes a `pagecustomization` object that defines the modification to the page. A separate file is created for customized page. For example, if you customized the **Customer** page for the **Business Manager** profile that is provided by the Base Application extension, the zip file would contain two files: **ProfileExtension._BUSINESS MANAGER.al** and **PageCustomization._Customer List_.Configuration2.al**. The files will contain code similar to the following:
 
-```
+```al
 profileextension BUSINESSMANAGER_1 extends "BUSINESS MANAGER"
 {
   Customizations = Configuration3;
@@ -123,7 +123,7 @@ profileextension BUSINESSMANAGER_1 extends "BUSINESS MANAGER"
 
 And:
 
-```
+```al
 pagecustomization Configuration3 customizes "Customer List"
 {
   layout


### PR DESCRIPTION
Three developer documentation files contain AL and C# code examples with bare triple-backtick fences, preventing syntax highlighting in the rendered docs.

devenv-role-customization.md: Five code blocks showing profile, pagecustomization, and profileextension objects had no language tag. Added al to each opening fence.

devenv-extending-best-price-calculations.md: One code block showing a codeunit implementing the Price Asset interface had no language tag. Added al.

devenv-dotnet-controladdins.md: Two code blocks were untagged. The C# class definition for the PingPong control add-in now has the csharp tag. The AL dotnet assembly block that follows now has the al tag.
