### PR TITLE
Add al language tag to AL code fences in upgrade documentation

### DIFF
--- a/dev-itpro/upgrade/Resolve-OnBeforeTestRun-OnAfterTestRun-Compile-Errors.md
+++ b/dev-itpro/upgrade/Resolve-OnBeforeTestRun-OnAfterTestRun-Compile-Errors.md
@@ -13,19 +13,19 @@ author: jswymer
 Use the [!INCLUDE[nav_dev_long_md](../developer/includes/nav_dev_long_md.md)] to change the signature of the C/AL OnBeforeTestRun and OnAfterTestRun trigger functions of the test runner codeunits to include the *TestPermissions* parameter.
 
 OnBeforeTestRun trigger before change:
-```
+```al
 OnBeforeTestRun(CodeunitID : Integer;CodeunitName : Text[30];FunctionName : Text[128];) Ok : Boolean)
 ```
 OnBeforeTestRun trigger after change:
-```
+```al
 OnBeforeTestRun(CodeunitID : Integer;CodeunitName : Text[30];FunctionName : Text[128];FunctionTestPermissions : TestPermissions) Ok : Boolean)
 ```
 OnAfterTestRun trigger before change:
-```
+```al
 OnAfterTestRun(CodeunitID : Integer;CodeunitName : Text[30];FunctionName : Text[128];Success : Boolean)
 ```
 OnAfterTestRun trigger after change:
-```
+```al
 OnAfterTestRun(CodeunitID : Integer;CodeunitName : Text[30];FunctionName : Text[128];FunctionTestPermissions : TestPermissions;Success : Boolean)
 ```
 If you don't change the signature, you get errors when you compile these objects.

--- a/dev-itpro/upgrade/handling-merge-conflicts.md
+++ b/dev-itpro/upgrade/handling-merge-conflicts.md
@@ -23,7 +23,7 @@ Because the CONFLICT files describe the conflicts, you can import the merged tex
 
 In most cases, the text files that contain the merged application objects clearly identify where the conflict is. The following code example illustrates an object that has a conflict.  
 
-```  
+```al
 PROCEDURE ApplicationBuild@3() : Text[80];  
 BEGIN  
   {>>>>>>>} ORIGINAL  

--- a/dev-itpro/upgrade/resolve-mysettings-page-after-upgrade.md
+++ b/dev-itpro/upgrade/resolve-mysettings-page-after-upgrade.md
@@ -33,13 +33,13 @@ When you convert a [!INCLUDE[navcorfu](../developer/includes/navcorfu_md.md)] da
         </tr>
         </table>
     2.  Add the following code to the **OpenSettings** function:
-        ```
+```al
         PAGE.RUN(PAGE::"My Settings");
         ```
 2. Modify page **9176 My Settings**:
 
     In AL code, replace the code on the local function **GetTimeZone** with the following code.
-    ```
+```al
     TimeZone.SETRANGE(ID,TimeZoneID);
     IF TimeZone.FINDFIRST THEN
         EXIT(TimeZone."Display Name");

--- a/dev-itpro/upgrade/resolve-page-6400-6401-error-converting-database.md
+++ b/dev-itpro/upgrade/resolve-page-6400-6401-error-converting-database.md
@@ -43,14 +43,14 @@ The resolution requires that you make changes to codeunit 6400, and pages 6400 a
       ```
     4. Add a global function called **GetTemplateFilter** that has a **Text** type return value, and add the code `EXIT(TemplateFilterTxt)` to the function:
 
-      ```
+```al
       GetTemplateFilter() : Text
           // Gets the default text value that filters Flow templates when opening page 6400.
           EXIT(TemplateFilterTxt);
       ```
 2. In page 6400 and 6401, in the `ControlAddinReady` function, replace the following code:
 
-    ``` 
+```al
     CurrPage.FlowAddin.Initialize(
       FlowServiceManagement.GetFlowUrl,FlowServiceManagement.GetLocale,
       AzureAdMgt.GetAccessToken(FlowServiceManagement.GetFlowARMResourceUrl,FlowServiceManagement.GetFlowResourceName,FALSE),
@@ -59,7 +59,7 @@ The resolution requires that you make changes to codeunit 6400, and pages 6400 a
     
     With the following code:
     
-    ```
+```al
     CurrPage.FlowAddin.Initialize(
             FlowServiceManagement.GetFlowUrl,FlowServiceManagement.GetLocale,
             AzureAdMgt.GetAccessToken(FlowServiceManagement.GetFlowARMResourceUrl,FlowServiceManagement.GetFlowResourceName,FALSE),

--- a/dev-itpro/upgrade/upgrade-codeunit-6400-flow-server-management-replacement-code.md
+++ b/dev-itpro/upgrade/upgrade-codeunit-6400-flow-server-management-replacement-code.md
@@ -16,7 +16,7 @@ This article includes replacement code codeunit **6400 Flow Server Management** 
 
 To fix the compilation errors, replace the code with the following:
 
-```
+```al
 codeunit 6400 "Flow Service Management"
 {
     // // Manages access to Power Automate service API

--- a/dev-itpro/upgrade/upgrade-page-6400-flow-template-selector-replacement-code.md
+++ b/dev-itpro/upgrade/upgrade-page-6400-flow-template-selector-replacement-code.md
@@ -16,7 +16,7 @@ This article includes replacement code page **6400 Flow Template Selector** that
 
 To fix the compilation errors, replace the code with the following:
 
-```
+```al
 page 6400 "Flow Template Selector"
 {
     ApplicationArea = Suite;


### PR DESCRIPTION
Six upgrade documentation files contain AL and C/AL code examples with bare triple-backtick fences. Without a language tag the renderer applies no syntax highlighting. Added the al tag to all opening fences wrapping AL or legacy C/AL code.

Files changed:

- handling-merge-conflicts.md: one C/AL PROCEDURE block
- resolve-mysettings-page-after-upgrade.md: two C/AL code blocks (PAGE.RUN and SETRANGE calls)
- Resolve-OnBeforeTestRun-OnAfterTestRun-Compile-Errors.md: four trigger signature blocks showing before and after the signature change
- resolve-page-6400-6401-error-converting-database.md: two C/AL code blocks (GetTemplateFilter and CurrPage.FlowAddin.Initialize calls)
- upgrade-codeunit-6400-flow-server-management-replacement-code.md: one AL codeunit block
- upgrade-page-6400-flow-template-selector-replacement-code.md: one AL page block
