### PR TITLE
Add powershell and csharp language tags to OAuth walkthrough code fences

### DIFF
--- a/dev-itpro/webservices/walkthrough-authenticate-web-services-using-oauth.md
+++ b/dev-itpro/webservices/walkthrough-authenticate-web-services-using-oauth.md
@@ -165,7 +165,7 @@ Install the latest version of the package by using NuGet Package Manager in Visu
 1. Select **Tools** > **NuGet Package Manager** > **Package Manager Console**.
 2. At the `PM>` prompt, enter the following command:
 
-    ```
+```powershell
     Install-Package Microsoft.Identity.Client -Version 4.40.0
     ```
 
@@ -175,7 +175,7 @@ Install the latest version of the package by using NuGet Package Manager in Visu
 
 1. In the code editor, write the following code. Replace brackets `<>` with your values.
 
-    ```
+```csharp
     using System;
     using System.Collections.Generic;
     using System.Linq;


### PR DESCRIPTION
The walkthrough-authenticate-web-services-using-oauth.md file has two code blocks with bare fences.

The NuGet Package Manager block wrapping Install-Package now carries the powershell tag.

The console application code block wrapping the C# using directives and class definition now carries the csharp tag.
