### PR TITLE
Correct 'a' to 'an' before vowel-initial words in devitpro docs

### DIFF
--- a/dev-itpro/administration/resources/dynamics_extension.md
+++ b/dev-itpro/administration/resources/dynamics_extension.md
@@ -23,7 +23,7 @@ Represents an extension in [!INCLUDE[d365fin_long_md](../../includes/d365fin_lon
 
 | Method | Return Type|Description |
 |:--------------------|:-----------|:-------------------------|
-|[GET extension](../api/dynamics_extension_get.md)|extension|Gets a extension object.|
+|[GET extension](../api/dynamics_extension_get.md)|extension|Gets an extension object.|
 
 ## Bound Actions
 

--- a/dev-itpro/administration/resources/dynamics_extensiondeploymentstatus.md
+++ b/dev-itpro/administration/resources/dynamics_extensiondeploymentstatus.md
@@ -22,7 +22,7 @@ Represents an extension deployment status in [!INCLUDE[d365fin_long_md](../../in
 
 | Method | Return Type|Description |
 |:--------------------|:-----------|:-------------------------|
-|[GET extensionDeploymentStatus](../api/dynamics_extensiondeploymentstatus_get.md)|extensionDeploymentStatus|Gets a extension deployment status object.|
+|[GET extensionDeploymentStatus](../api/dynamics_extensiondeploymentstatus_get.md)|extensionDeploymentStatus|Gets an extension deployment status object.|
 
 
 

--- a/dev-itpro/administration/resources/dynamics_extensionupload.md
+++ b/dev-itpro/administration/resources/dynamics_extensionupload.md
@@ -23,9 +23,9 @@ Represents an extension upload in [!INCLUDE[d365fin_long_md](../../includes/d365
 
 | Method | Return Type|Description |
 |:--------------------|:-----------|:-------------------------|
-|[GET extensionUpload](../api/dynamics_extensionupload_get.md)|extensionUpload|Gets a extension upload object.|
-|[POST extensionUpload](../api/dynamics_extensionupload_create.md)|extensionUpload|Creates a extension upload object.|
-|[PATCH extensionUpload](../api/dynamics_extensionupload_update.md)|extensionUpload|Updates a extension upload object.|
+|[GET extensionUpload](../api/dynamics_extensionupload_get.md)|extensionUpload|Gets an extension upload object.|
+|[POST extensionUpload](../api/dynamics_extensionupload_create.md)|extensionUpload|Creates an extension upload object.|
+|[PATCH extensionUpload](../api/dynamics_extensionupload_update.md)|extensionUpload|Updates an extension upload object.|
 
 ## Bound Actions
 

--- a/dev-itpro/developer/includes/include-report-exception-paragraphs.md
+++ b/dev-itpro/developer/includes/include-report-exception-paragraphs.md
@@ -154,7 +154,7 @@ This happens when a developer is debugging a report
 Not an error<br><br>
 
 ### <a name=NavNCLDialogException></a>NavNCLDialogException
-The NavNCLDialogException error happens when a error function has been called in the report. 
+The NavNCLDialogException error happens when an error function has been called in the report. 
 
 **Suggested solution**<br>
 The error messages will in most cases provide the necessary information to mitigate the problem. If not, you need a developer to debug the report or the code running the report. If the report was supplied by Microsoft or an ISV, then create a support request.<br><br>

--- a/dev-itpro/whatsnew/preview-feature-details.md
+++ b/dev-itpro/whatsnew/preview-feature-details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Feature details in update 28.0 public preview for 2026 release wave 1
 description: Feature details for Business Central 2026 release wave 1
 ms.date: 02/28/2026
@@ -132,7 +132,7 @@ You configure these approvals under **Workflows**:
 2.  Select an **Item Journal Batch Approval Workflow** or **Requisition Worksheet Batch Approval Workflow** workflow template.
 3.  Specify the template and batch in the event conditions.
 3.  Configure approvers, and enable the workflow.
-4.  Open a item journal or requisition/planning worksheet, and choose the **Send for approval** action.
+4.  Open an item journal or requisition/planning worksheet, and choose the **Send for approval** action.
 5.  Track the status of the approval in the **Status** field on the **Approval Entries** page.
 
 Microsoft Power Automate support is available through updated workflow events and responses, with guidance provided as part of the enhancement.


### PR DESCRIPTION
Five files use 'a' before words that start with a vowel sound, where the correct article is 'an'.

include-report-exception-paragraphs.md: 'when a error function' corrected to 'when an error function'.

preview-feature-details.md: 'Open a item journal' corrected to 'Open an item journal'.

dynamics_extension.md: 'Gets a extension object' corrected to 'Gets an extension object'.

dynamics_extensiondeploymentstatus.md: 'Gets a extension deployment status object' corrected to 'Gets an extension deployment status object'.

dynamics_extensionupload.md: Three operations table entries (GET, POST, PATCH) each used 'a extension'. All three corrected to 'an extension'.
