### PR TITLE
Correct article errors before vowel-initial words in admin and developer docs

### DIFF
--- a/dev-itpro/administration/migration-table-mapping.md
+++ b/dev-itpro/administration/migration-table-mapping.md
@@ -63,7 +63,7 @@ For example, suppose the Business Central on-premises table is named **My Custom
 
 The following figure illustrates an example of the **Migrate Table Mappings** page for an AL table:
 
-[![Shows the table mapping move for a AL table](../media/table-mapping-move-al.png)](../media/table-mapping-move-al.png#lightbox)
+[![Shows the table mapping move for an AL table](../media/table-mapping-move-al.png)](../media/table-mapping-move-al.png#lightbox)
 
 ## Move a set of fields out of the main table to another table or table extension
 

--- a/dev-itpro/administration/server-trace-events.md
+++ b/dev-itpro/administration/server-trace-events.md
@@ -160,7 +160,7 @@ The following table lists the arguments that make up the data collected for trac
 |category|Specifies the category of the telemetry trace event.|Telemetry (TelemetryData)|  
 |connectionType|Specifies the [!INCLUDE[rtc](../developer/includes/rtc_md.md)] that has established the connection to the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] server instance. Values include [!INCLUDE[nav_windows](../developer/includes/nav_windows_md.md)] and [!INCLUDE[nav_web](../developer/includes/nav_web_md.md)].|Service calls (ServiceCall)|
 |dataclassification|Specifies the [!INCLUDE[rtc](../developer/includes/rtc_md.md)] that has established the connection to the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] server instance. Values include [!INCLUDE[nav_windows](../developer/includes/nav_windows_md.md)] and [!INCLUDE[nav_web](../developer/includes/nav_web_md.md)].|Service calls (ServiceCall)|    
-|failureMessage|Includes the error message that is returned when a AL function fails.|AL function trace events (ALTracing)|  
+|failureMessage|Includes the error message that is returned when an AL function fails.|AL function trace events (ALTracing)|  
 |functionName|Specifies the AL function that was executed.|AL function trace events (ALTracing)|
 |lineNumber|Specifies the line number of the statement in the AL code of the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] object that was executed.|AL function trace events|  
 |message|Specifies the error, warning, or information message text that was issued for a trace event|Windows event log trace events (EventViewer)<br /><br />Telemetry (TelemetryData)|  

--- a/dev-itpro/administration/telemetry-environment-lifecycle-trace.md
+++ b/dev-itpro/administration/telemetry-environment-lifecycle-trace.md
@@ -1503,7 +1503,7 @@ Occurs when a configuration key for the environment failed to be deleted.
 
 ### Sample KQL code (environment configuration key failed to be deleted)
 
-This KQL code can help you get started analyzing failures when deletin a environment configuration key:
+This KQL code can help you get started analyzing failures when deleting an environment configuration key:
 
 ```kql
 traces
@@ -1551,7 +1551,7 @@ Occurs when the update window for the environment was successfully updated.
 
 ## Environment update window modification failed
 
-Occurs when a update window failed to be updated.
+Occurs when an update window failed to be updated.
 
 ### General dimensions
 

--- a/dev-itpro/developer/analyzers/codecop-aa0221.md
+++ b/dev-itpro/developer/analyzers/codecop-aa0221.md
@@ -1,6 +1,6 @@
 ---
 title: "CodeCop Warning AA0221"
-description: "You must specify a OptionCaption property for all fields which source expressions is not a table field."
+description: "You must specify an OptionCaption property for all fields which source expressions is not a table field."
 ms.author: solsen
 ms.date: 08/26/2024
 ms.topic: reference
@@ -11,10 +11,10 @@ ms.reviewer: solsen
 [//]: # (IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT.)
 [//]: # (Any modifications should be made in the .xml files in the ModernDev repo.)
 # CodeCop Warning AA0221
-You must specify a OptionCaption property for all fields which source expressions is not a table field.
+You must specify an OptionCaption property for all fields which source expressions is not a table field.
 
 ## Description
-You must specify a OptionCaption property for all fields which source expressions is not a table field.
+You must specify an OptionCaption property for all fields which source expressions is not a table field.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## Related information  

--- a/dev-itpro/developer/analyzers/codecop.md
+++ b/dev-itpro/developer/analyzers/codecop.md
@@ -72,7 +72,7 @@ CodeCop is an analyzer that enforces the official AL Coding Guidelines.
 |[AA0218](codecop-aa0218.md)|You must write a tooltip in the Tooltip property for all controls of type Action and Field that exist on page objects.|Localizability|Warning|
 |[AA0219](codecop-aa0219.md)|The Tooltip property of Fields should start with 'Specifies'.|Localizability|Info|
 |[AA0220](codecop-aa0220.md)|The value of the Tooltip property of Fields must be filled.|Localizability|Warning|
-|[AA0221](codecop-aa0221.md)|You must specify a OptionCaption property for all fields which source expressions is not a table field.|Localizability|Warning|
+|[AA0221](codecop-aa0221.md)|You must specify an OptionCaption property for all fields which source expressions is not a table field.|Localizability|Warning|
 |[AA0222](codecop-aa0222.md)|SIFT index should not be used on primary or unique key.|Design|Warning|
 |[AA0223](codecop-aa0223.md)|The value of the OptionCaption property of Fields must be filled in.|Localizability|Warning|
 |[AA0224](codecop-aa0224.md)|The count of option captions specified in the OptionCaption property is wrong.|Localizability|Warning|

--- a/dev-itpro/developer/methods-auto/variant/variant-isobjecttype-method.md
+++ b/dev-itpro/developer/methods-auto/variant/variant-isobjecttype-method.md
@@ -30,7 +30,7 @@ An instance of the [Variant](variant-data-type.md) data type.
 ## Return Value
 *Ok*  
 &emsp;Type: [Boolean](../boolean/boolean-data-type.md)  
-**true** if the AL variant contains a ObjectType variable, otherwise **false**.
+**true** if the AL variant contains an ObjectType variable, otherwise **false**.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)


### PR DESCRIPTION
Correct "a" to "an" before vowel-initial words across 6 files in admin and developer docs.

Changes:

- migration-table-mapping.md: "for a AL table" to "for an AL table" in image alt text
- server-trace-events.md: "when a AL function fails" to "when an AL function fails"
- telemetry-environment-lifecycle-trace.md: "deletin a environment" to "deleting an environment"; "a update window" to "an update window"
- codecop-aa0221.md: "a OptionCaption property" to "an OptionCaption property" (rule title and body)
- codecop.md: "a OptionCaption property" to "an OptionCaption property" (rule index table)
- variant-isobjecttype-method.md: "a ObjectType variable" to "an ObjectType variable"

Note: telemetry-environment-lifecycle-trace.md line 1506 also had a truncated word ("deletin") which is corrected to "deleting" in the same change.
