### PR TITLE
Correct spelling errors in test method and upgrade docs

### DIFF
--- a/dev-itpro/developer/methods-auto/pagebackgroundtaskerrorlevel/pagebackgroundtaskerrorlevel-option.md
+++ b/dev-itpro/developer/methods-auto/pagebackgroundtaskerrorlevel/pagebackgroundtaskerrorlevel-option.md
@@ -18,11 +18,12 @@ Specifies how an error in the page background task appears in the client.
 ## Members
 |  Member  |  Description  |
 |----------------|---------------|
-|Error|Error occuring in a page background task is displayed as an normal error in the client. This is the default value.|
-|Warning|Error occuring in a page background task is displayed as an warning in the client. **Note:** Any error thrown in completion trigger will ignore this value and will be displayed in the client as a normal error.|
-|Ignore|Error occuring in a page background task is not displayed in the client. **Note:** Any error thrown in completion trigger will ignore this value and will be displayed in the client as a normal error.|
+|Error|Error occurring in a page background task is displayed as a normal error in the client. This is the default value.|
+|Warning|Error occurring in a page background task is displayed as a warning in the client. **Note:** Any error thrown in completion trigger will ignore this value and will be displayed in the client as a normal error.|
+|Ignore|Error occurring in a page background task is not displayed in the client. **Note:** Any error thrown in completion trigger will ignore this value and will be displayed in the client as a normal error.|
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 ## Related information  
 [Get Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)  
+

--- a/dev-itpro/developer/methods-auto/testrequestpage/testrequestpage-getvalidationerror-method.md
+++ b/dev-itpro/developer/methods-auto/testrequestpage/testrequestpage-getvalidationerror-method.md
@@ -33,7 +33,7 @@ The index of the validation error that occurred on the test page.
 ## Return Value
 *Error*  
 &emsp;Type: [Text](../text/text-data-type.md)  
-The validation error that occured at the specified index.
+The validation error that occurred at the specified index.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)

--- a/dev-itpro/developer/methods-auto/testrequestpage/testrequestpage-saveasxml-method.md
+++ b/dev-itpro/developer/methods-auto/testrequestpage/testrequestpage-saveasxml-method.md
@@ -29,7 +29,7 @@ An instance of the [TestRequestPage](testrequestpage-data-type.md) data type.
 
 *ParameterFileName*  
 &emsp;Type: [Text](../text/text-data-type.md)  
-The path and file name to which the paramater file is saved.  
+The path and file name to which the parameter file is saved.  
 
 *DataSetFileName*  
 &emsp;Type: [Text](../text/text-data-type.md)  

--- a/dev-itpro/upgrade/upgrade-codeunit-6400-flow-server-management-replacement-code.md
+++ b/dev-itpro/upgrade/upgrade-codeunit-6400-flow-server-management-replacement-code.md
@@ -36,7 +36,7 @@ codeunit 6400 "Flow Service Management"
         FlowEnvironmentsProdApiTxt: Label 'https://management.azure.com/providers/Microsoft.ProcessSimple/environments?api-version=2016-11-01', Locked = true;
         FlowEnvironmentsTip1ApiTxt: Label 'https://tip1.api.powerapps.com/providers/Microsoft.PowerApps/environments?api-version=2016-11-01', Locked = true;
         FlowEnvironmentsTip2ApiTxt: Label 'https://tip2.api.powerapps.com/providers/Microsoft.PowerApps/environments?api-version=2016-11-01', Locked = true;
-        GenericErr: Label 'An error occured while trying to access the Flow service. Please try again or contact your system administrator if the error persists.';
+        GenericErr: Label 'An error occurred while trying to access the Flow service. Please try again or contact your system administrator if the error persists.';
         FlowResourceNameTxt: Label 'Flow Services';
         FlowTemplatePageSizeTxt: Label '4', Locked = true;
         FlowTemplateDestinationNewTxt: Label 'new', Locked = true;
@@ -392,3 +392,4 @@ codeunit 6400 "Flow Service Management"
 ## Related information
 
 [Code Conversion from C/AL to AL](devenv-code-conversion.md)  
+


### PR DESCRIPTION
Correct spelling errors across four developer and upgrade method docs.

Changes:

- pagebackgroundtaskerrorlevel-option.md: "occuring" to "occurring" in all three option descriptions; also corrects "an normal error" to "a normal error" and "an warning" to "a warning" on those same lines
- testrequestpage-getvalidationerror-method.md: "occured" to "occurred" in the return value description
- testrequestpage-saveasxml-method.md: "paramater" to "parameter" in the parameter description
- upgrade-codeunit-6400-flow-server-management-replacement-code.md: "occured" to "occurred" inside the GenericErr label string
