### PR TITLE
Remove doubled words and correct typos in developer and analyzer docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0128.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0128.md
@@ -11,7 +11,7 @@ ms.reviewer: solsen
 [//]: # (IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT.)
 [//]: # (Any modifications should be made in the .xml files in the ModernDev repo.)
 # AppSourceCop Error AS0128
-An interface must not be removed from the the list of extended interfaces on an interface that has been published.
+An interface must not be removed from the list of extended interfaces on an interface that has been published.
 
 ## Description
 An interface must not be removed from the list of extended interfaces on an interface that has been published, because dependent extensions may break

--- a/dev-itpro/developer/analyzers/appsourcecop-as0129.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0129.md
@@ -11,7 +11,7 @@ ms.reviewer: solsen
 [//]: # (IMPORTANT:Do not edit any of the content between here and the END>DO_NOT_EDIT.)
 [//]: # (Any modifications should be made in the .xml files in the ModernDev repo.)
 # AppSourceCop Error AS0129
-An interface must not be added to the the list of extended interfaces on an interface that has been published.
+An interface must not be added to the list of extended interfaces on an interface that has been published.
 
 ## Description
 An interface must not be added to the list of extended interfaces on an interface that has been published, because dependent extensions may break

--- a/dev-itpro/developer/attributes/devenv-eventsubscriber-attribute.md
+++ b/dev-itpro/developer/attributes/devenv-eventsubscriber-attribute.md
@@ -37,7 +37,7 @@ Specifies the type of object that publishes the event to subscribe to.
 
 *ObjectId*  
 &emsp;Type: [Integer](../methods-auto/integer/integer-data-type.md)  
-Specifies the ID of the object that that publishes the event to subscribe to. You can specify the object by its ID (integer) or by its name using the syntax `<ObjectType>::<ObjectName>`, such as `Codeunit::MyEventPublisher`. Using the name is the recommended way.  
+Specifies the ID of the object that publishes the event to subscribe to. You can specify the object by its ID (integer) or by its name using the syntax `<ObjectType>::<ObjectName>`, such as `Codeunit::MyEventPublisher`. Using the name is the recommended way.  
 
 *EventName*  
 &emsp;Type: [Text](../methods-auto/text/text-data-type.md)  
@@ -118,3 +118,4 @@ codeunit 50107 MyEventSubscriber
 [Raising events](../devenv-raising-events.md)   
 [Subscribing to events](../devenv-subscribing-to-events.md)   
 [Method attributes](devenv-method-attributes.md)
+

--- a/dev-itpro/developer/methods-auto/report/reportinstance-formatregion-method.md
+++ b/dev-itpro/developer/methods-auto/report/reportinstance-formatregion-method.md
@@ -42,9 +42,9 @@ The current format region setting for the report.
 
 ## Example
 
-If you have reports that you want to print using a format that is aligned with the recepient rather than in your own working region, you can add a few lines of code in the report to handle this. In this example we will take the assumption that the format region will be aligned with the language in the current report run and that the report does not have native support for format region. The document is printed in the language that is specified in the **Language Code** field on the **Customer Card** page.
+If you have reports that you want to print using a format that is aligned with the recipient rather than in your own working region, you can add a few lines of code in the report to handle this. In this example we will take the assumption that the format region will be aligned with the language in the current report run and that the report does not have native support for format region. The document is printed in the language that is specified in the **Language Code** field on the **Customer Card** page.
 
-In reports that need the multiple document format functionality, you can insert the following AL code as the first lines in the `OnAfterGetRecord()` trigger on the data item referencing the **Customer** table (notice that that feature is not limited to the **Customer** table, other data sources provides similar functionality.):
+In reports that need the multiple document format functionality, you can insert the following AL code as the first lines in the `OnAfterGetRecord()` trigger on the data item referencing the **Customer** table (notice that feature is not limited to the **Customer** table, other data sources provides similar functionality.):
 
 ```AL
 trigger OnAfterGetRecord()
@@ -67,3 +67,5 @@ end;
 [Report Data Type](report-data-type.md)  
 [Getting Started with AL](../../devenv-get-started.md)  
 [Developing Extensions](../../devenv-dev-overview.md)   
+
+

--- a/dev-itpro/whatsnew/preview-feature-details.md
+++ b/dev-itpro/whatsnew/preview-feature-details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Feature details in update 28.0 public preview for 2026 release wave 1
 description: Feature details for Business Central 2026 release wave 1
 ms.date: 02/28/2026
@@ -467,7 +467,7 @@ The following are more details about the changes we made to each report.
 
 **Revenue Forecast**
 
-* Added conditional formatting to more effectively analyse revenue forecast trends and outliers, and align with the sales app.
+* Added conditional formatting to more effectively analyze revenue forecast trends and outliers, and align with the sales app.
 
 **Billing Forecast**
 
@@ -1137,6 +1137,7 @@ Shopify order headers now include the **retailLocation** (ID and name). Business
 ### Update unit cost when syncing prices to Shopify
 
 When you turn off the **Sync Prices with Products** toggle, Business Central previously updated the **Unit Cost** field on the item variant entry but didn't send the change to Shopify. With this improvement, the unit cost is included in all price synchronization operations, both individual and bulk. When you sync prices, the **Price** and **Compare at Price** fields, and now the **Unit Cost** field, update in Shopify and correctly revert if a bulk operation fails.
+
 
 
 


### PR DESCRIPTION
Remove doubled words and correct typos across five developer and analyzer docs.

Changes:

- appsourcecop-as0128.md: "from the the list" changed to "from the list"
- appsourcecop-as0129.md: "to the the list" changed to "to the list"
- devenv-eventsubscriber-attribute.md: "the object that that publishes" changed to "the object that publishes"
- reportinstance-formatregion-method.md: "notice that that feature" changed to "notice that feature"; also corrects "recepient" to "recipient"
- preview-feature-details.md: "analyse revenue forecast" changed to "analyze revenue forecast" (American English; the same bullet point two lines below already used "analyze")
