### PR TITLE
Correct article errors before vowel-initial words in telemetry and OData docs

### DIFF
--- a/dev-itpro/administration/administration-custom-option-mapping.md
+++ b/dev-itpro/administration/administration-custom-option-mapping.md
@@ -230,7 +230,7 @@ To track whether an industry group is coupled to an industry code in [!INCLUDE[c
 
 3. Add a control that shows the **Coupled to CRM** field on the list page. There are no naming requirements for the control.
 
-Every time you couple or uncouple a record from your [!INCLUDE[prod_short](../includes/prod_short.md)] table to a option set in [!INCLUDE[cds_long_md](../includes/cds_long_md.md)], the synchronization engine will update the Coupled to CRM field that you added.
+Every time you couple or uncouple a record from your [!INCLUDE[prod_short](../includes/prod_short.md)] table to an option set in [!INCLUDE[cds_long_md](../includes/cds_long_md.md)], the synchronization engine will update the Coupled to CRM field that you added.
 
 This will only update records that you couple or uncouple after you have added the Coupled to CRM field. To update this field value on records that were coupled before you added the Coupled to CRM field, you must run the following code. We recommend that you run the code as a background task.
 
@@ -631,3 +631,4 @@ Users can now manually synchronize industry group records in [!INCLUDE[prod_shor
 [Mapping the Tables and Fields to Synchronize](/dynamics365/business-central/admin-how-to-modify-table-mappings-for-synchronization)  
 [Manually Synchronize Table Mappings](/dynamics365/business-central/admin-manual-synchronization-of-table-mappings)  
 [Schedule a Synchronization](/dynamics365/business-central/admin-scheduled-synchronization-using-the-synchronization-job-queue-entries)
+

--- a/dev-itpro/administration/telemetry-environment-lifecycle-trace.md
+++ b/dev-itpro/administration/telemetry-environment-lifecycle-trace.md
@@ -1430,7 +1430,7 @@ Occurs when a configuration key for the environment failed to be updated.
 
 ### Sample KQL code (environment configuration key failed to update)
 
-This KQL code can help you get started analyzing failures when setting a environment configuration key:
+This KQL code can help you get started analyzing failures when setting an environment configuration key:
 
 ```kql
 traces
@@ -2259,3 +2259,4 @@ traces
 
 [Monitoring and Analyzing Telemetry](telemetry-overview.md)  
 [Enable Sending Telemetry to Application Insights](telemetry-enable-application-insights.md)  
+

--- a/dev-itpro/webservices/odata-client-performance.md
+++ b/dev-itpro/webservices/odata-client-performance.md
@@ -47,7 +47,7 @@ Similarly to the `$select` clause guidelines, specify the properties in the `$se
 
 ## Using a filter on `LastModifiedOn` when you query for historical data
 
-When you query for historical data, the chances are that you're interested in the most recent period (for example, 30 days, 90 days). Because of how data audit fields are implemented in the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] database, there is a update of the data in the `LastModifiedOn` system field, which makes it perfect for history filters.
+When you query for historical data, the chances are that you're interested in the most recent period (for example, 30 days, 90 days). Because of how data audit fields are implemented in the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] database, there is an update of the data in the `LastModifiedOn` system field, which makes it perfect for history filters.
 
 ## Using `$top` query option to limit the number of records
 
@@ -77,3 +77,4 @@ Whatever your approach is, run both queries multiple times. For example, run the
 [OData Web Services](OData-Web-Services.md)  
 [Web service performance](web-service-performance.md)  
 [Business Central web services overview](web-services.md)  
+


### PR DESCRIPTION
Correct "a" to "an" before vowel-initial words in three admin and web services docs.

Changes:

- telemetry-environment-lifecycle-trace.md: "setting a environment configuration key" changed to "setting an environment configuration key"
- administration-custom-option-mapping.md: "to a option set" changed to "to an option set"
- odata-client-performance.md: "there is a update of the data" changed to "there is an update of the data"
