### PR TITLE
Correct 'a use' to 'a user' in telemetry error message voting doc

### DIFF
--- a/dev-itpro/administration/telemetry-error-message-voting-trace.md
+++ b/dev-itpro/administration/telemetry-error-message-voting-trace.md
@@ -24,7 +24,7 @@ This voting feature appears on all error messages that are thrown by calls to th
 
 ## <a name="succeeded"></a>User gave feedback on error message
 
-Occurs when a use selects either **Yes** or **No** to the question on the error dialog as to whether the message was helpful.
+Occurs when a user selects either **Yes** or **No** to the question on the error dialog as to whether the message was helpful.
 
 ### General dimensions
 
@@ -81,3 +81,4 @@ The following table explains the custom dimensions included in the trace.
 
 [Monitoring and Analyzing Telemetry](telemetry-overview.md)  
 [Enable Sending Telemetry to Application Insights](telemetry-enable-application-insights.md)  
+


### PR DESCRIPTION
Correct typo in telemetry-error-message-voting-trace.md where 'a use selects' should read 'a user selects'. The word 'user' was truncated to 'use', losing the final 'r'.
