### PR TITLE
Add powershell language tag to bare code fences in admin and deployment docs

### DIFF
--- a/dev-itpro/administration/configure-server-instance-archived.md
+++ b/dev-itpro/administration/configure-server-instance-archived.md
@@ -483,7 +483,7 @@ The [!INCLUDE[adminshell](../developer/includes/adminshell.md)] includes several
 
 The main cmdlet for configuring a server instance is the Set-NAVServerConfiguration cmdlet. You can use this cmdlet to change any of the configuration settings that are listed in the previous sections. To change a configuration setting, you set `-KeyName` parameter to the **Key Name** that corresponds to the setting, and set the `-KeyValue` parameter to the new value. For example, you can change the value for `DatabaseServer` to `DatabaseServer.Domain.Com` for the server instance named `MyInstance` by executing this cmdlet:  
 
-```  
+```powershell
 Set-NAVServerConfiguration -ServerInstance "MyInstance" -KeyName "DatabaseServer" -KeyValue "DatabaseServer.Domain.Com"  
 ```  
 
@@ -499,7 +499,7 @@ For dynamically updatable settings, use the `-ApplyTo` parameter to specify how 
 
 For example, the following command sets the value for the `MaxStreamReadSize` key to `42424242`, without having to restart the server instance. 
 
-```  
+```powershell
 Set-NAVServerConfiguration -ServerInstanceMyInstance -KeyName MaxStreamReadSize -KeyValue 42424242 -ApplyTo Memory  
 ```
 

--- a/dev-itpro/administration/configure-server-instance.md
+++ b/dev-itpro/administration/configure-server-instance.md
@@ -437,7 +437,7 @@ The [!INCLUDE[adminshell](../developer/includes/adminshell.md)] includes several
 
 The main cmdlet for configuring a server instance is the Set-NAVServerConfiguration cmdlet. You can use this cmdlet to change any of the configuration settings that are listed in the previous sections. To change a configuration setting, you set `-KeyName` parameter to the **Key Name** that corresponds to the setting, and set the `-KeyValue` parameter to the new value. For example, you can change the value for `DatabaseServer` to `DatabaseServer.Domain.Com` for the server instance named `MyInstance` by executing this cmdlet:  
 
-```  
+```powershell
 Set-NAVServerConfiguration -ServerInstance "MyInstance" -KeyName "DatabaseServer" -KeyValue "DatabaseServer.Domain.Com"  
 ```  
 
@@ -453,7 +453,7 @@ For dynamically updatable settings, use the `-ApplyTo` parameter to specify how 
 
 For example, the following command sets the value for the `MaxStreamReadSize` key to `42424242`, without having to restart the server instance. 
 
-```  
+```powershell
 Set-NAVServerConfiguration -ServerInstanceMyInstance -KeyName MaxStreamReadSize -KeyValue 42424242 -ApplyTo Memory  
 ```
 

--- a/dev-itpro/administration/monitor-long-running-sql-queries-event-log.md
+++ b/dev-itpro/administration/monitor-long-running-sql-queries-event-log.md
@@ -22,7 +22,7 @@ The threshold of when a SQL query is considered to be long running is controlled
 
 You can also change the setting by [Set-NAVServerConfiguration cmdlet](/powershell/module/microsoft.dynamics.nav.management/set-navserverconfiguration) in [!INCLUDE[adminshell](../developer/includes/adminshell.md)]. The cmdlet includes the `-ApplyTo Memory`parameter that enables you to change the setting without doing a server restart. For example, to change the threshold dynamically to 2000 ms, run the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] Administration Shell as Administrator and then type the following PowerShell cmdlet:
 
-```
+```powershell
 Set-NAVServerConfiguration -ServerInstance <ServerInstanceName> -KeyName SqlLongRunningThreshold -KeyValue 2000 -ApplyTo Memory
 ```
 

--- a/dev-itpro/administration/monitor-server-events-with-powershell.md
+++ b/dev-itpro/administration/monitor-server-events-with-powershell.md
@@ -73,7 +73,7 @@ You can filter the events that you view in a [!INCLUDE[server](../developer/incl
   
 The following example uses the Get-WinEvent cmdlet to view errors in the [!INCLUDE[server](../developer/includes/server.md)] Admin log for the tenant *MyTenant1* on the server instance *MyNavServerInstance1*.  
   
-```  
+```powershell
 Get-WinEvent -LogName 'Microsoft-DynamicsNAV-Server/Admin' -FilterXPath "*[System[(Level=2)]] and *[EventData[Data[@Name='tenantId'] and (Data = 'MyTenant1')]] and *[EventData[Data[@Name='serverInstanceName'] and Data='MyNavServerInstance1']]" | Format-List -Property Message-  
 ```  
   

--- a/dev-itpro/deployment/How-to--Export-the-Application-Tables-to-a-Dedicated-Database.md
+++ b/dev-itpro/deployment/How-to--Export-the-Application-Tables-to-a-Dedicated-Database.md
@@ -83,7 +83,7 @@ In [!INCLUDE[prod_short](../developer/includes/prod_short.md)], you can export t
 
  The sample commands are assumed to run in the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] administration shell based on the [!INCLUDE[demolong](../developer/includes/demolong_md.md)] on a local computer.  
 
-```  
+```powershell
 Stop-NAVServerInstance –ServerInstance ‘nav_server_instance’ 
 Export-NAVApplication –DatabaseServer ‘MyServer’ –DatabaseInstance ‘NAVDEMO’ –DatabaseName ‘Demo Database NAV (11-0)’ –DestinationDatabaseName ‘NAV App’| Remove-NAVApplication –DatabaseName ‘Demo Database NAV (11-0)’ -Force
 Set-NAVServerConfiguration –ServerInstance ‘nav_server_instance’ –element appSettings –KeyName ‘DatabaseName’ –KeyValue ‘’

--- a/dev-itpro/deployment/Separating-Application-Data-from-Business-Data.md
+++ b/dev-itpro/deployment/Separating-Application-Data-from-Business-Data.md
@@ -220,7 +220,7 @@ For more information, see [Business Central Windows PowerShell Cmdlets](/powersh
 
  The sample commands are assumed to run in the [!INCLUDE[prod_short](../developer/includes/prod_short.md)] administration shell based on the [!INCLUDE[demolong](../developer/includes/demolong_md.md)] on a local computer.  
 
-```  
+```powershell
 Stop-NAVServerInstance –ServerInstance 'businesscentral_server_instance' 
 Export-NAVApplication –DatabaseServer 'MyServer' –DatabaseInstance 'BCDEMO' –DatabaseName 'Demo Database BC' –DestinationDatabaseName 'Business Central App'| Remove-NAVApplication –DatabaseName 'Demo Database BC' -Force
 Set-NAVServerConfiguration –ServerInstance 'businesscentral_server_instance' –element appSettings –KeyName 'DatabaseName' –KeyValue ''

--- a/dev-itpro/developer/devenv-system-application-overview.md
+++ b/dev-itpro/developer/devenv-system-application-overview.md
@@ -95,7 +95,7 @@ You now have the latest version of the System Application, and you can download 
 
 7. Switch back to PowerShell and run the following cmdlet to publish and install a new version of the app:
 
-```
+```powershell
 Publish-BCContainerApp -containerName $containerName `
 
 -appFile "C:\ProgramData\BCContainerHelper\AL\DemoSolution\Microsoft_System Application_15.0.0.0.app" `


### PR DESCRIPTION
Adding missing `powershell` language tags to bare code fences in admin, deployment, and developer docs.

Without a language identifier, fences render without syntax highlighting, making command-line examples harder to read.

Files updated:

- `dev-itpro/administration/configure-server-instance-archived.md` (2 fences)
- `dev-itpro/administration/configure-server-instance.md` (2 fences)
- `dev-itpro/administration/monitor-long-running-sql-queries-event-log.md` (1 fence)
- `dev-itpro/administration/monitor-server-events-with-powershell.md` (1 fence)
- `dev-itpro/deployment/How-to--Export-the-Application-Tables-to-a-Dedicated-Database.md` (1 fence)
- `dev-itpro/deployment/Separating-Application-Data-from-Business-Data.md` (1 fence)
- `dev-itpro/developer/devenv-system-application-overview.md` (1 fence)

All affected blocks contain `Set-NAVServerConfiguration`, `Get-WinEvent`, `Stop-NAVServerInstance`, or `Publish-BCContainerApp` commands.
