### PR TITLE
Add powershell language tag to bare code fences in 13 upgrade docs

### DIFF
--- a/dev-itpro/upgrade/Upgrading-the-Application-Code.md
+++ b/dev-itpro/upgrade/Upgrading-the-Application-Code.md
@@ -250,25 +250,25 @@ The application and tenant databases are tagged with `Family` and `Version`. To 
 
 To get the `Family` and `Version`, use the [Get-NAVApplication](/powershell/module/microsoft.dynamics.nav.management/get-navapplication) cmdlet, for example:
 
-```  
+```powershell
 Get-NAVApplication -ServerInstance BC
 ```
 
 To set the `Family` and `Version`, use the [Set-NAVApplication](/powershell/module/microsoft.dynamics.nav.management/set-navapplication) cmdlet. For example, to set the family, run the following command:
 
-```
+```powershell
 Set-NAVApplication -ServerInstance <ServerInstanceName> -ApplicationFamily <Family> 
 ```
 
 To increase the version by 1, run the following command:
 
-```
+```powershell
 Set-NAVApplication -ServerInstance <ServerInstanceName> -IncrementApplicationVersion
 ```
 
 Or, to specify change to another version, run the following command:
 
-```
+```powershell
 Set-NAVApplication -ServerInstance <ServerInstanceName> -ApplicationVersion <N.N.N.N> -Force
 ```
 

--- a/dev-itpro/upgrade/Upgrading-the-Data.md
+++ b/dev-itpro/upgrade/Upgrading-the-Data.md
@@ -231,19 +231,19 @@ Use the [Set-NAVApplication](/powershell/module/microsoft.dynamics.nav.managemen
 
 To see the current version, use the following command:
 
-```
+```powershell
 Get-NAVApplication -ServerInstance <ServerInstanceName>
 ```
 
 To increase the version by 1, run the following command:
 
-```
+```powershell
 Set-NAVApplication -ServerInstance <ServerInstanceName> -IncrementApplicationVersion
 ```
 
 Or, to specify change to another version, run the following command:
 
-```
+```powershell
 Set-NAVApplication -ServerInstance <ServerInstanceName> -ApplicationVersion <N.N.N.N> -Force
 ```
 
@@ -255,13 +255,13 @@ Synchronize the database schema with validation.
 
 For example, run the [Sync-NAVTenant](/powershell/module/microsoft.dynamics.nav.management/sync-navtenant) cmdlet from the [!INCLUDE[adminshell](../developer/includes/adminshell.md)]. 
 
-```
+```powershell
 Sync-NAVTenant -ServerInstance <ServerInstanceName>
 ```
 
 When completed, the tenant (database) should have the status **OperationalDataUpgradePending**. To verify this, run the following cmdlet:
 
-```
+```powershell
 Get-NAVTenant -ServerInstance <ServerInstanceName> -tenant default
 ```
 

--- a/dev-itpro/upgrade/upgrade-destinationappsformigration.md
+++ b/dev-itpro/upgrade/upgrade-destinationappsformigration.md
@@ -49,12 +49,12 @@ The DestinationAppsForMigration setting serves the following purposes:
 
 You can only set the DestinationAppsForMigration by using the Set-NAVServerConfiguration cmdlet. To specify an extension, you must know the extension's ID, name, and publisher. The following code snippet shows the syntax for setting the DestinationAppsForMigration:
 
-```
+```powershell
 Set-NAVServerConfiguration -ServerInstance <server instance name> -KeyName "DestinationAppsForMigration" -KeyValue '[{"appId":"<GUID>, "name":"<Extension name>", "publisher": "<Publisher>"},{"appId":"<GUID>, "name":"<Extension name>", "publisher": "<Publisher>"}]'
 ```
 For example, the following command specifies the Microsoft system and base applications and a custom extension named My Extension.
 
-```
+```powershell
 Set-NAVServerConfiguration -ServerInstance <server instance name> -KeyName "DestinationAppsForMigration" -KeyValue '[{"appId":"63ca2fa4-4f03-4f2b-a480-172fef340d3f", "name":"System Application", "publisher": "Microsoft"},{"appId":"437dbf0e-84ff-417a-965d-ed2bb9650972", "name":"Base Application", "publisher": "Microsoft"},{"appId":"00001111-aaaa-2222-bbbb-3333cccc4444", "name":"My Extension", "publisher": "Me"}]'
 ```
 

--- a/dev-itpro/upgrade/upgrade-publish-extensions.md
+++ b/dev-itpro/upgrade/upgrade-publish-extensions.md
@@ -18,7 +18,7 @@ This article describes how to publish, upgrade and install extension when upgrad
 
 It is useful to get a list of the extensions that are currently published for future reference. To get list of the extensions currently published on the application, run the following command:
 
-```
+```powershell
 Get-NAVAppinfo -ServerInstance <ServerInstanceName>
 ```
 
@@ -88,7 +88,7 @@ The new extension versions are found in the `\Extensions` folder of the installa
 
 To publish the new extension version, run the [Publish-NAVApp](/powershell/module/microsoft.dynamics.nav.apps.management/publish-navapp) cmdlet: 
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <ServerInstanceName> -Path <ExtensionFileName> 
 ```
            
@@ -96,7 +96,7 @@ Publish-NAVApp -ServerInstance <ServerInstanceName> -Path <ExtensionFileName>
 
 For each extension, run the [Sync-NAVApp](/powershell/module/microsoft.dynamics.nav.apps.management/sync-navapp) cmdlet:
 
-```
+```powershell
 Sync-NavApp -ServerInstance <ServerInstanceName> -Name  <ExtensionFileName>  -Version N.N.N.N -Tenant <TenantID>
 ```
 
@@ -108,7 +108,7 @@ This step is not required for the newly published local functionality extensions
 
 To run the data upgrade, run the [Start-NAVAppDataUpgrade](/powershell/module/microsoft.dynamics.nav.apps.management/start-navappdataupgrade) cmdlet:
 
-```
+```powershell
 Start-NAVAppDataUpgrade -ServerInstance <ServerInstanceName> -Name <Name> -Version <N.N.N.N>
 ``` 
 
@@ -118,7 +118,7 @@ Apart from upgrading the data, this command will install the new extension versi
 
 Install the newly published local functionality extensions by running the [Install-NAVApp](/powershell/module/microsoft.dynamics.nav.apps.management/install-navapp) cmdlet:
 
-```    
+```powershell
 Install-NAVApp -ServerInstance <ServerInstanceName> -Name <Name> -Version <N.N.N.N>
 ```
 For more information about publishing extensions, see [Publish and Install an Extension](../developer/devenv-how-publish-and-install-an-extension-v2.md).

--- a/dev-itpro/upgrade/upgrade-technical-upgrade-v15-v16.md
+++ b/dev-itpro/upgrade/upgrade-technical-upgrade-v15-v16.md
@@ -152,7 +152,7 @@ When you installed version 16 in **Task 1**, a version 16 [!INCLUDE[server](../d
 
 Use the Publish-NAVApp cmdlet to publish the new symbols extension package. This package is called **System.app**. If you've installed the **AL Development Environment**, you find the file in the installation folder. By default, the folder path is C:\Program Files (x86)\Microsoft Dynamics 365 Business Central\160\AL Development Environment.
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <BC16 server instance> -Path "<path to the System.app file>" -PackageType SymbolsOnly
 ```
 

--- a/dev-itpro/upgrade/upgrade-technical-upgrade-v15-v17.md
+++ b/dev-itpro/upgrade/upgrade-technical-upgrade-v15-v17.md
@@ -196,7 +196,7 @@ When you installed version 17 in **Task 1**, a version 17 [!INCLUDE[server](../d
 
 Use the Publish-NAVApp cmdlet to publish the new symbols extension package. This package is called **System.app**. If you've installed the **AL Development Environment**, you find the file in the installation folder. By default, the folder path is C:\Program Files (x86)\Microsoft Dynamics 365 Business Central\170\AL Development Environment.
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <BC17 server instance> -Path "<path to the System.app file>" -PackageType SymbolsOnly
 ```
 
@@ -204,7 +204,7 @@ Publish-NAVApp -ServerInstance <BC17 server instance> -Path "<path to the System
 
 Publish the new versions of the system and base application extensions.
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <BC17 server instance> -Path "<path to .app file for system or base application>" 
 ```
 

--- a/dev-itpro/upgrade/upgrade-unmodified-application-v14-v16.md
+++ b/dev-itpro/upgrade/upgrade-unmodified-application-v14-v16.md
@@ -205,13 +205,13 @@ The version has the format `major.minor.build.revision`, such as, '14.3.14824.1'
 
 To change the application version, run the [Set-NAVApplication cmldet](/powershell/module/microsoft.dynamics.nav.management/set-navapplication):
 
-```
+```powershell
 Set-NAVApplication -ServerInstance <server instance name> -ApplicationVersion <new application version> -Force
 ```
 
 For example:
 
-```
+```powershell
 Set-NAVApplication -ServerInstance BC160 -ApplicationVersion 16.0.38071.0 -Force
 ```
 
@@ -409,7 +409,7 @@ If you have a multitenant deployment, do these steps for each tenant.
 
 Complete this task to install third-party extensions for which a new version wasn't published. For each extension, run the [Install-NAVApp cmdlet](/powershell/module/microsoft.dynamics.nav.apps.management/install-navapp):
 
-```
+```powershell
 Install-NAVApp -ServerInstance <server instance name> -Name <extension name> -Version <extension version>
 ```
 

--- a/dev-itpro/upgrade/upgrade-unmodified-application-v15-to-v16.md
+++ b/dev-itpro/upgrade/upgrade-unmodified-application-v15-to-v16.md
@@ -345,7 +345,7 @@ Run the data upgrade on extensions in order of dependency.
 
 On each tenant, run the [Start-NavDataUpgrade](/powershell/module/microsoft.dynamics.nav.management/start-navdataupgrade) cmdlet as follows to change the version number:
     
-```
+```powershell
 Start-NAVDataUpgrade -ServerInstance <server instance name> -Tenant <tenant ID> -FunctionExecutionMode Serial -SkipAppVersionCheck
 ```
 
@@ -353,7 +353,7 @@ Start-NAVDataUpgrade -ServerInstance <server instance name> -Tenant <tenant ID> 
 
 Complete this task to install third-party extensions for which a new version wasn't published. For each extension, run the [Install-NAVApp cmdlet](/powershell/module/microsoft.dynamics.nav.apps.management/install-navapp):
 
-```
+```powershell
 Install-NAVApp -ServerInstance <server instance name> -Name <extension name> -Version <extension version>
 ```
 

--- a/dev-itpro/upgrade/upgrade-unmodified-application-v15-to-v17.md
+++ b/dev-itpro/upgrade/upgrade-unmodified-application-v15-to-v17.md
@@ -349,7 +349,7 @@ Run the data upgrade on extensions in order of dependency.
 
 On each tenant, run the [Start-NavDataUpgrade](/powershell/module/microsoft.dynamics.nav.management/start-navdataupgrade) cmdlet as follows:
 
-```
+```powershell
 Start-NAVDataUpgrade -ServerInstance <server instance name> -Tenant <tenant ID> -FunctionExecutionMode Serial -SkipAppVersionCheck
 ```
 
@@ -359,7 +359,7 @@ This command will upgrade and install the extensions on the tenant.
 
 Complete this task to install third-party extensions for which a new version wasn't published. For each extension, run the [Install-NAVApp cmdlet](/powershell/module/microsoft.dynamics.nav.apps.management/install-navapp):
 
-```
+```powershell
 Install-NAVApp -ServerInstance <server instance name> -Name <extension name> -Version <extension version>
 ```
 

--- a/dev-itpro/upgrade/upgrade-unmodified-application-v16-to-v17.md
+++ b/dev-itpro/upgrade/upgrade-unmodified-application-v16-to-v17.md
@@ -339,7 +339,7 @@ Run the data upgrade on extensions in order of dependency.
 
 On each tenant, run the [Start-NavDataUpgrade](/powershell/module/microsoft.dynamics.nav.management/start-navdataupgrade) cmdlet as follows:
     
-```
+```powershell
 Start-NAVDataUpgrade -ServerInstance <server instance name> -Tenant <tenant ID> -FunctionExecutionMode Serial -SkipAppVersionCheck
 ```
 
@@ -349,7 +349,7 @@ This command will upgrade and install the extensions on the tenant.
 
 Complete this task to install third-party extensions for which a new version wasn't published. For each extension, run the [Install-NAVApp cmdlet](/powershell/module/microsoft.dynamics.nav.apps.management/install-navapp):
 
-```
+```powershell
 Install-NAVApp -ServerInstance <server instance name> -Name <extension name> -Version <extension version>
 ```
 

--- a/dev-itpro/upgrade/upgrading-cumulative-update-v15.md
+++ b/dev-itpro/upgrade/upgrading-cumulative-update-v15.md
@@ -237,7 +237,7 @@ For more information, see [Uploading a License File for a Specific Database](../
 
 Use the Publish-NAVApp cmdlet to publish the new symbols extension package. This package is called **System.app**. If you install the **AL Development Environment**, you find the file in the installation folder. By default, the folder path is C:\Program Files (x86)\Microsoft Dynamics 365 Business Central\150\AL Development Environment. Or, it's also on the installation media (DVD) in the ModernDev\program files\Microsoft Dynamics NAV\150\AL Development Environment folder.
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <server instance> -Path "<path to the System.app file>" -PackageType SymbolsOnly
 ```
 

--- a/dev-itpro/upgrade/upgrading-cumulative-update-v16.md
+++ b/dev-itpro/upgrade/upgrading-cumulative-update-v16.md
@@ -243,7 +243,7 @@ For more information, see [Uploading a License File for a Specific Database](../
 
 Use the Publish-NAVApp cmdlet to publish the new symbols extension package. This package is called **System.app**. If you've installed the **AL Development Environment**, you find the file in the installation folder. By default, the folder path is C:\Program Files (x86)\Microsoft Dynamics 365 Business Central\160\AL Development Environment. Or, it's also on the installation media (DVD) in the ModernDev\program files\Microsoft Dynamics NAV\160\AL Development Environment folder.
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <server instance> -Path "<path to the System.app file>" -PackageType SymbolsOnly
 ```
 

--- a/dev-itpro/upgrade/upgrading-cumulative-update-v17.md
+++ b/dev-itpro/upgrade/upgrading-cumulative-update-v17.md
@@ -248,7 +248,7 @@ For more information, see [Uploading a License File for a Specific Database](../
 
 Use the Publish-NAVApp cmdlet to publish the new symbols extension package. This package is called **System.app**. If you've installed the **AL Development Environment**, you find the file in the installation folder. By default, the folder path is C:\Program Files (x86)\Microsoft Dynamics 365 Business Central\170\AL Development Environment. Or, it's also on the installation media (DVD) in the ModernDev\program files\Microsoft Dynamics NAV\170\AL Development Environment folder.
 
-```
+```powershell
 Publish-NAVApp -ServerInstance <server instance> -Path "<path to the System.app file>" -PackageType SymbolsOnly
 ```
 


### PR DESCRIPTION
Adding missing `powershell` language tags to bare code fences across 13 upgrade documentation files.

Without a language identifier, fences render without syntax highlighting, making upgrade command examples harder to follow.

Files updated (31 fences total):

- `upgrade-destinationappsformigration.md` (2 fences)
- `upgrade-publish-extensions.md` (5 fences)
- `upgrade-technical-upgrade-v15-v16.md` (1 fence)
- `upgrade-technical-upgrade-v15-v17.md` (2 fences)
- `upgrade-unmodified-application-v14-v16.md` (3 fences)
- `upgrade-unmodified-application-v15-to-v16.md` (2 fences)
- `upgrade-unmodified-application-v15-to-v17.md` (2 fences)
- `upgrade-unmodified-application-v16-to-v17.md` (2 fences)
- `upgrading-cumulative-update-v15.md` (1 fence)
- `upgrading-cumulative-update-v16.md` (1 fence)
- `upgrading-cumulative-update-v17.md` (1 fence)
- `Upgrading-the-Application-Code.md` (4 fences)
- `Upgrading-the-Data.md` (5 fences)

All affected blocks contain Business Central upgrade commands such as `Publish-NAVApp`, `Sync-NAVApp`, `Start-NAVAppDataUpgrade`, `Install-NAVApp`, and related cmdlets.
