### PR TITLE
Add json language tag to bare code fences in telemetry and JSON method docs

### DIFF
--- a/dev-itpro/administration/monitor-long-running-sql-queries-event-log.md
+++ b/dev-itpro/administration/monitor-long-running-sql-queries-event-log.md
@@ -92,7 +92,7 @@ The following tables explains the columns included in long running query events 
 
 The following shows an example of the CustomDimensions exported in CSV format.
  
-```
+```json
 {"Long running log threshold (ms)":"65","Telemetry schema version":"0.1","Execution time (ms)":"99","Component":"Navision_NAVPlatform - 15.0.35274.0","Environment type":"Production","SQL Statement":"SELECT \"2161\".\"timestamp\",\"2161\".\"User\",\"2161\".\"Default Execute Time\",\"2161\".\"Current Job Queue Entry\",\"2161\".\"$systemId\" FROM \"SQLDATABASE\".dbo.\"CURRENTCOMPANY$Calendar Event User Config_\" \"2161\"  WITH(UPDLOCK)  WHERE (\"2161\".\"User\"=@0) OPTION(OPTIMIZE FOR UNKNOWN)","Client Type":"Background","AL Stack Trace":"AppObjectType: CodeUnit\r\n  AppObjectId: 2160\r\n  AL CallStack: \"Calendar Event Mangement\"(CodeUnit 2160).GetCalendarEventUserConfiguration line 2\r\n\"Calendar Event Management\"(CodeUnit 2160).FindJobQueue line 1\r\n\"Calendar Event Execution\"(CodeUnit 2161).RunCalendarEvents line 20\r\n\"Calendar Event Execution\"(CodeUnit 2161).OnRun(Trigger) line 1\r\n\"Job Queue Start Codeunit\"(CodeUnit 449).OnRun(Trigger) line 6\r\n\"Job Queue Dispatcher\"(CodeUnit 448).HandleRequest line 18\r\n\"Job Queue Dispatcher\"(CodeUnit 448).OnRun(Trigger) line 12","AL Object Name":"Calendar Event Mangement","AL Object type":"CodeUnit","Company Name":"CRONUS International Ltd.","AL Object ID":"2160"}
 ```
 

--- a/dev-itpro/administration/telemetry-long-running-sql-query-trace.md
+++ b/dev-itpro/administration/telemetry-long-running-sql-query-trace.md
@@ -55,7 +55,7 @@ This table explains the columns included in long running query events emitted to
 
 
 <!-- 
-```
+```json
 {"telemetrySchemaVersion":"0.3","executionTimeInMs":"99","component":"Dynamics Business Central Server - 15.0.35274.0","environmentType":"Production","sqlStatement":"SELECT \"2161\".\"timestamp\",\"2161\".\"User\",\"2161\".\"Default Execute Time\",\"2161\".\"Current Job Queue Entry\",\"2161\".\"$systemId\" FROM \"SQLDATABASE\".dbo.\"CURRENTCOMPANY$Calendar Event User Config_\" \"2161\"  WITH(UPDLOCK)  WHERE (\"2161\".\"User\"=@0) OPTION(OPTIMIZE FOR UNKNOWN)","clientType":"Background","alStackTrace":"AppObjectType: CodeUnit\r\n  AppObjectId: 2160\r\n  AL CallStack: \"Calendar Event Management\"(CodeUnit 2160).GetCalendarEventUserConfiguration line 2\r\n\"Calendar Event Management\"(CodeUnit 2160).FindJobQueue line 1\r\n\"Calendar Event Execution\"(CodeUnit 2161).RunCalendarEvents line 20\r\n\"Calendar Event Execution\"(CodeUnit 2161).OnRun(Trigger) line 1\r\n\"Job Queue Start Codeunit\"(CodeUnit 449).OnRun(Trigger) line 6\r\n\"Job Queue Dispatcher\"(CodeUnit 448).HandleRequest line 18\r\n\"Job Queue Dispatcher\"(CodeUnit 448).OnRun(Trigger) line 12","alObjectName":"Calendar Event Management","alObjectType":"CodeUnit","companyName":"CRONUS International Ltd.","alObjectId":"2160"}
 ```
 

--- a/dev-itpro/administration/telemetry-reports-trace.md
+++ b/dev-itpro/administration/telemetry-reports-trace.md
@@ -491,7 +491,7 @@ traces
 The following table explains the CustomDimensions included in report generation traces.
 
 
-```
+```json
 {"extensionVersion":"16.0.11335.0","Telemetry schema version":"0.3","telemetrySchemaVersion":"0.3","serverExecutionTime":"00:00:07.0126616","Component version":"16.0.11329.0","Environment type":"Production","componentVersion":"16.0.11329.0","environmentType":"Production","deprecatedKeys":"Company name, AL Object Id, AL Object type, AL Object name, AL Stack trace, Client type, Extension name, Extension App Id, Extension version, Telemetry schema version, AadTenantId, Environment name, Environment type, Component, Component version, Telemetry schema version","sqlExecutes":"213","aadTenantId":"common","companyName":"CRONUS International Ltd.","sqlRowsRead":"320","AadTenantId":"common","clientType":"WebClient","Component":"Dynamics 365 Business Central Server","totalTime":"00:00:07.0753414","component":"Dynamics 365 Business Central Server","result":"Success","alObjectName":"Inventory - Sales Back Orders","alStackTrace":"AppObjectType: Report\r\n AppObjectId: 718","Company name":"CRONUS International Ltd.","Extension version":"16.0.11335.0","alObjectType":"Report","AL Stack trace":"AppObjectType: Report\r\n AppObjectId: 718","extensionId":"437dbf0e-84ff-417a-965d-ed2bb9650972","Client type":"WebClient","AL Object name":"Inventory - Sales Back Orders","alObjectId":"718","AL Object type":"Report","extensionName":"Base Application","Extension App Id":"437dbf0e-84ff-417a-965d-ed2bb9650972","Extension name":"Base Application","numberOfRows":"50","AL Object Id":"718"}
 ```
 -->

--- a/dev-itpro/administration/telemetry-stop-session-trace.md
+++ b/dev-itpro/administration/telemetry-stop-session-trace.md
@@ -52,7 +52,7 @@ The following table describes the most relevant custom dimensions of the trace.
 
 <sup>*</sup><a name="1"></a> Not shown for sessions canceled from the admin center.
 <!--
-```
+```json
 {"result":"False","stoppingSessionID":"448999","cancellationComment":"Stopped by management PowerShell cmdlet.","component":"Dynamics 365 Business Central Server","environmentType":"Production","stoppingSessionIsAdmin":"False","eventId":"RT0029","clientType":"ManagementClient","telemetrySchemaVersion":"0.1","currentSessionID":"910803","componentVersion":"20.0.42653.43979","environmentName":"Production","aadTenantId":"aaaabbbb-0000-cccc-1111-dddd2222eeee"}-->
 
 <!--

--- a/dev-itpro/developer/methods-auto/jsonarray/jsonarray-selecttoken-method.md
+++ b/dev-itpro/developer/methods-auto/jsonarray/jsonarray-selecttoken-method.md
@@ -51,7 +51,7 @@ The following example shows how to select a value from a complex JSON Object. We
 
 We assume that the company token contains JSON data similar to the one below.
 
-```
+```json
 { "company": {
     "employees": [
       { "id": "Marcy",

--- a/dev-itpro/developer/methods-auto/jsonobject/jsonobject-selecttoken-method.md
+++ b/dev-itpro/developer/methods-auto/jsonobject/jsonobject-selecttoken-method.md
@@ -50,7 +50,7 @@ The following example shows how to select a value from a complex JSON Object. We
 
 We assume that the company token contains JSON data similar to the one below.
 
-```
+```json
 { "company": {
     "employees": [
       { "id": "Marcy",

--- a/dev-itpro/developer/methods-auto/jsontoken/jsontoken-selecttoken-method.md
+++ b/dev-itpro/developer/methods-auto/jsontoken/jsontoken-selecttoken-method.md
@@ -50,7 +50,7 @@ The following example shows how to select a value from a complex JSON Object. We
 
 We assume that the company token contains JSON data similar to the one below.
 
-```
+```json
 { "company": {
     "employees": [
       { "id": "Marcy",


### PR DESCRIPTION
Adding missing `json` language tags to bare code fences in telemetry trace docs and JSON method docs.

Without a language identifier, fences render without syntax highlighting, making JSON payload examples harder to read.

Files updated (7 fences total):

- `dev-itpro/administration/monitor-long-running-sql-queries-event-log.md` (1 fence)
- `dev-itpro/administration/telemetry-long-running-sql-query-trace.md` (1 fence)
- `dev-itpro/administration/telemetry-reports-trace.md` (1 fence)
- `dev-itpro/administration/telemetry-stop-session-trace.md` (1 fence)
- `dev-itpro/developer/methods-auto/jsonarray/jsonarray-selecttoken-method.md` (1 fence)
- `dev-itpro/developer/methods-auto/jsonobject/jsonobject-selecttoken-method.md` (1 fence)
- `dev-itpro/developer/methods-auto/jsontoken/jsontoken-selecttoken-method.md` (1 fence)

All affected blocks contain JSON telemetry payloads or JSON example data.
