### PR TITLE
Correct typos in test page and AppSourceCop analyzer docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0135.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0135.md
@@ -32,7 +32,7 @@ Alternatively, if the intention is only to remove the containing object or proce
 
 ## Examples triggering this rule
 
-### Example 1 - Removing an external business event (independant of the object / procedure accessibilty)
+### Example 1 - Removing an external business event (independent of the object / procedure accessibility)
 
 Version 1 of the extension
 

--- a/dev-itpro/developer/methods-auto/testpage/testpage-getvalidationerror-method.md
+++ b/dev-itpro/developer/methods-auto/testpage/testpage-getvalidationerror-method.md
@@ -33,7 +33,7 @@ The index of the validation error that occurred on the test page.
 ## Return Value
 *Error*  
 &emsp;Type: [Text](../text/text-data-type.md)  
-A string where each line represents a validation error that occured on the test page.
+A string where each line represents a validation error that occurred on the test page.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)

--- a/dev-itpro/developer/methods-auto/testpart/testpart-getvalidationerror-method.md
+++ b/dev-itpro/developer/methods-auto/testpart/testpart-getvalidationerror-method.md
@@ -33,7 +33,7 @@ The index of the validation error that occurred on the test page.
 ## Return Value
 *Error*  
 &emsp;Type: [Text](../text/text-data-type.md)  
-A string where each line represents a validation error that occured on the test page.
+A string where each line represents a validation error that occurred on the test page.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)

--- a/dev-itpro/developer/methods-auto/testpart/testpart-validationerrorcount-method.md
+++ b/dev-itpro/developer/methods-auto/testpart/testpart-validationerrorcount-method.md
@@ -28,7 +28,7 @@ An instance of the [TestPart](testpart-data-type.md) data type.
 ## Return Value
 *Count*  
 &emsp;Type: [Integer](../integer/integer-data-type.md)  
-Number of validation errors that occured on the test page.
+Number of validation errors that occurred on the test page.
 
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)


### PR DESCRIPTION
Correcting spelling errors across test page method docs and the AppSourceCop AS0135 analyzer doc.

Changes:

- `dev-itpro/developer/methods-auto/testpage/testpage-getvalidationerror-method.md`: "occured" to "occurred"
- `dev-itpro/developer/methods-auto/testpart/testpart-getvalidationerror-method.md`: "occured" to "occurred"
- `dev-itpro/developer/methods-auto/testpart/testpart-validationerrorcount-method.md`: "occured" to "occurred"
- `dev-itpro/developer/analyzers/appsourcecop-as0135.md`: "independant" to "independent" and "accessibilty" to "accessibility" in the Example 1 section heading
