### PR TITLE
Correct British spellings to American English in analyzer and whatsnew docs

### DIFF
--- a/dev-itpro/developer/analyzers/uicop-aw0013.md
+++ b/dev-itpro/developer/analyzers/uicop-aw0013.md
@@ -122,7 +122,7 @@ page 50100 MyPage
 
 There's no impact on the promoted section of the command bar as promoted actions remain visible. There's also no impact on the default section of the command bar since promoted actions are promoted only and non-promoted actions remain hidden.  
 
-Use this approach if you want to keep the current behaviour.
+Use this approach if you want to keep the current behavior.
 
 > [!IMPORTANT]
 > The behavior of the [PromotedOnly](..\properties\devenv-promotedonly-property.md) property changes with Business Central 2022 release wave 2 since the platform handles the duplicity of promoted actions.
@@ -161,3 +161,4 @@ Use this approach if you didn't expect `MyPromotedAction` to appear in the promo
 [UICop Analyzer](uicop.md)  
 [Getting Started with AL](../devenv-get-started.md)  
 [Developing Extensions](../devenv-dev-overview.md)  
+

--- a/dev-itpro/whatsnew/preview-feature-details.md
+++ b/dev-itpro/whatsnew/preview-feature-details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Feature details in update 28.0 public preview for 2026 release wave 1
 description: Feature details for Business Central 2026 release wave 1
 ms.date: 02/28/2026
@@ -467,7 +467,7 @@ The following are more details about the changes we made to each report.
 
 **Revenue Forecast**
 
-* Added conditional formatting to more effectively analyse revenue forecast trends and outliers, and align with the sales app.
+* Added conditional formatting to more effectively analyze revenue forecast trends and outliers, and align with the sales app.
 
 **Billing Forecast**
 
@@ -1137,6 +1137,7 @@ Shopify order headers now include the **retailLocation** (ID and name). Business
 ### Update unit cost when syncing prices to Shopify
 
 When you turn off the **Sync Prices with Products** toggle, Business Central previously updated the **Unit Cost** field on the item variant entry but didn't send the change to Shopify. With this improvement, the unit cost is included in all price synchronization operations, both individual and bulk. When you sync prices, the **Price** and **Compare at Price** fields, and now the **Unit Cost** field, update in Shopify and correctly revert if a bulk operation fails.
+
 
 
 

--- a/dev-itpro/whatsnew/whatsnew-update-18-2.md
+++ b/dev-itpro/whatsnew/whatsnew-update-18-2.md
@@ -48,10 +48,11 @@ All customers can now receive up-front email notifications seven days in advance
 In the upcoming June update to Power BI Desktop we have included a new connector for Business Central allowing you to get data faster from Business Central to Power BI. Note the update to Power BI Desktop is scheduled later in June and you will get it automatically if you have installed Power BI Desktop from Microsoft Store. Read more about the new capabilities [here](/dynamics365-release-plan/2021wave1/smb/dynamics365-business-central/enable-power-bi-connector-work-business-central-apis-instead-web-services-only). Please note that this change is for Business Central online only. 
 
 **AboutTitle and AboutText properties**  
-We’ve updated [AL reference docs](/dynamics365/business-central/dev-itpro/developer/properties/devenv-abouttitle-property) with plenty of details, including the list of page combinations where the About properties have different or no effect. Update 18.2 fully reflects these behaviours.
+We’ve updated [AL reference docs](/dynamics365/business-central/dev-itpro/developer/properties/devenv-abouttitle-property) with plenty of details, including the list of page combinations where the About properties have different or no effect. Update 18.2 fully reflects these behaviors.
 
 **Business Central Office Hours Calls in June**  
 Make sure to join the office hours calls around 'Working with Dimensions' on June 15 and 'DevOps for Per Tenant Extensions' on June 29. Register and stay tuned for the upcoming calls: https://aka.ms/BCOfficeHours. Also, notice that in the month of July, there will be no office hours calls. 
 
 **Support for migrating data from earlier on-premises versions of Business Central to 2021 release wave 1 (v.18)**  
 With the Business Central cloud migration tool, customers can migrate their data from earlier on-premises versions of the product to their online Business Central environment, running on the latest version. We've added support for customers who are running on Business Central on-premises version 14, 15, 16, or 17 to migrate their data to version 18 of Business Central online. We've implemented the necessary data upgrade logic in the cloud migration tool, so customers don't have to upgrade their older version themselves in order to migrate their data to the latest online release. 
+

--- a/dev-itpro/whatsnew/whatsnew-update-21-1.md
+++ b/dev-itpro/whatsnew/whatsnew-update-21-1.md
@@ -22,7 +22,7 @@ Find an overview of hotfixes in this [article](https://support.microsoft.com/top
 
 - [Access Business Central with your Microsoft 365 license](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/access-business-central-365-license)
 -  [Embed Business Central in Teams tabs](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/embed-business-central-teams-tabs)
-- [Auto-Save as you work:](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/auto-save-as-work) due to popular demand, administrators can now choose to turn on or off the new auto-saving behaviour using Feature Management
+- [Auto-Save as you work:](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/auto-save-as-work) due to popular demand, administrators can now choose to turn on or off the new auto-saving behavior using Feature Management
 - [Business Central is available in 11 more countries/regions](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/planned-features#country-and-regional)
 - [Accessibility declaration for Italy available](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/accessibility-declaration-italy)
 - [Use SharePoint Connector module in System Application to build integration between Business Central and Sharepoint](/dynamics365-release-plan/2022wave2/smb/dynamics365-business-central/use-sharepoint-module-system-application-build-integrations-between-business-central-sharepoint) 
@@ -81,3 +81,4 @@ Register and stay tuned for upcoming calls: [aka.ms/BCOfficeHours](https://aka.m
 
 **Discover resources on aka.ms/BCAll**  
 Are you looking for relevant resources? Find it all in this article [aka.ms/BCAll](https://aka.ms/BCAll) and remember to bookmark it!
+


### PR DESCRIPTION
Correcting British spellings to American English in documentation prose.

Changes:

- `dev-itpro/developer/analyzers/uicop-aw0013.md`: "behaviour" to "behavior" in prose recommendation (the file already uses "behavior" in the adjacent NOTE block)
- `dev-itpro/whatsnew/whatsnew-update-18-2.md`: "behaviours" to "behaviors"
- `dev-itpro/whatsnew/whatsnew-update-21-1.md`: "behaviour" to "behavior"
- `dev-itpro/whatsnew/preview-feature-details.md`: "analyse" to "analyze"

Instances inside AL code comment blocks (such as `// runtime behaviour`) are intentionally not changed.
