### PR TITLE
Drop superfluous 'to' after 'helps' in five docs

### DIFF
--- a/dev-itpro/deployment/installation-considerations-for-microsoft-sql-server.md
+++ b/dev-itpro/deployment/installation-considerations-for-microsoft-sql-server.md
@@ -119,7 +119,7 @@ Even with AUTO_UPDATE_STATISTICS on, we recommend running a periodic SQL Agent j
 
 #### Index fragmentation
 
-Another important administration task that helps to reduce data size and improve performance is to reduce fragmentation for tables and nonclustered indexes. Learn more in [Resolve index fragmentation by reorganizing or rebuilding indexes](/sql/relational-databases/indexes/reorganize-and-rebuild-indexes).
+Another important administration task that helps reduce data size and improve performance is to reduce fragmentation for tables and nonclustered indexes. Learn more in [Resolve index fragmentation by reorganizing or rebuilding indexes](/sql/relational-databases/indexes/reorganize-and-rebuild-indexes).
 
 #### Other database options
 

--- a/dev-itpro/developer/devenv-extending-best-price-calculations.md
+++ b/dev-itpro/developer/devenv-extending-best-price-calculations.md
@@ -257,7 +257,7 @@ The Price Source Group interface defines methods for a generic price source grou
 * Vendor (21)
 * Job (31)
 
-This enum is the subset of the Price Source Type enum. Both enums implement the Price Source Group interface. The interface helps to link the Price Source Type enum with the Sale Price Source Type, Purchase Price Source Type, and Job Price Source Type enums.
+This enum is the subset of the Price Source Type enum. Both enums implement the Price Source Group interface. The interface helps link the Price Source Type enum with the Sale Price Source Type, Purchase Price Source Type, and Job Price Source Type enums.
 
 :::image type="content" source="../media/best-pricing-price-sources-group.png" alt-text="Diagram showing a price sources group.":::
 

--- a/dev-itpro/developer/devenv-update-app-life-cycle-faq.md
+++ b/dev-itpro/developer/devenv-update-app-life-cycle-faq.md
@@ -56,7 +56,7 @@ Yes, we have some valuable tips we would like to share. These are tips that can 
 
 - Follow the checklist, for more information, see [Technical Validation Checklist](devenv-checklist-submission.md). The checklist is ever evolving and requirements might change or be added. You might miss something from the checklist, leading to validation failure and delaying the passing of your updated app.
 - Follow the technical validation FAQ, for more information, see [Technical Validation FAQ](devenv-checklist-submission-faq.md). We're regularly updating it based on the questions and support cases raised by partners.
-- Use AppSourceCop, for more information, see [Using the Code Analysis Tool](devenv-using-code-analysis-tool.md). This helps to catch any missing prefix/suffix and DataClassification. Too often we see these fail the updated versions of apps.
+- Use AppSourceCop, for more information, see [Using the Code Analysis Tool](devenv-using-code-analysis-tool.md). This helps catch any missing prefix/suffix and DataClassification. Too often we see these fail the updated versions of apps.
 - Sign your app. This fails many app validations. We try to publish the app during validation and it isn't properly code-signed leading to failure to publish.
 - Publish and install your app. This is another significant validation failure we see too often.
 - Test your app’s functionality with 100% coverage. You're the expert on the app and know it best. If you're only testing a small percentage of your app, customers will most likely find issues resulting in you having to update your app more often. And if customers are the ones finding your app issues, they might decide to uninstall it. You should have a vested interest in providing a quality app.

--- a/dev-itpro/help/writing-guide.md
+++ b/dev-itpro/help/writing-guide.md
@@ -339,7 +339,7 @@ Messages that users see when they work in [!INCLUDE [prod_short](../developer/in
 
 - Don't place quotation marks around placeholders.
 
-    However, if the placeholder represents free-text user input that is hard to distinguish, such as a payment comment on a bank transaction. The quotation marks then helps to distinguish the user input from other parts of the message.  
+    However, if the placeholder represents free-text user input that is hard to distinguish, such as a payment comment on a bank transaction. The quotation marks then help distinguish the user input from other parts of the message.  
 
     Example: *The payment line with transaction text '%1' isn't applied.*, where %1 = `Hi - here is my payment of invoice 1223344`.  
 

--- a/dev-itpro/security/security-lock-down-server-communication.md
+++ b/dev-itpro/security/security-lock-down-server-communication.md
@@ -35,7 +35,7 @@ The [!INCLUDE[prod_short](../developer/includes/prod_short.md)] instance include
 |SOAPServicesSSLEnabled​|false||
 |ClientServicesProtection|EncryptAndSign|Protects the data stream between clients and [!INCLUDE[server](../developer/includes/server.md)] instance. For background information, see [Understanding Protection Level](/dotnet/framework/wcf/understanding-protection-level)|
 |ReportAppDomainIsolation​|||
-|ClientServicesMaxUploadSize​|30MB|Helps to avoid out-of-memory errors.|
+|ClientServicesMaxUploadSize​|30MB|Helps avoid out-of-memory errors.|
 |RestrictedFileTypes​ (ClientServicesProhibitedFileTypes)||Prevents specific file types from uploaded to the database from the client. |
 |EnableDataExportImport​|||
 |EnableALServerFileAccess​|true|Specifies whether access to server files by AL file data type functions is allowed.|


### PR DESCRIPTION
Five docs use "helps to [verb]" where "to" is superfluous. Per Microsoft Writing Style Guide, "helps" takes a bare infinitive.

Additionally, `writing-guide.md` has a subject-verb agreement error: "quotation marks then **helps**" where the plural subject "marks" requires "help".

Changes:
- `installation-considerations-for-microsoft-sql-server.md`: "helps to reduce" to "helps reduce"
- `security-lock-down-server-communication.md`: "Helps to avoid" to "Helps avoid"
- `devenv-update-app-life-cycle-faq.md`: "helps to catch" to "helps catch"
- `devenv-extending-best-price-calculations.md`: "helps to link" to "helps link"
- `writing-guide.md`: "then helps to distinguish" to "then help distinguish" (agreement + bare infinitive)
