### PR TITLE
Simplify 'in order to' to 'to' in developer AL docs

### DIFF
--- a/dev-itpro/developer/devenv-adding-actions-to-a-page.md
+++ b/dev-itpro/developer/devenv-adding-actions-to-a-page.md
@@ -32,7 +32,7 @@ Learn more about different types of actions and where to use them in [Actions ov
 
 The page actions are displayed on the header section. There are multiple tabs to help navigate to the right item.
   
-In order to add actions to the action bar, you must use the keywords with Anchors or Targets. These keywords are used to place and move the actions around in the tab groups. Learn more about adding, moving, and modifying actions in [Using keywords to place actions and controls](devenv-page-ext-object.md#using-keywords-to-place-actions-and-controls).
+To add actions to the action bar, you must use the keywords with Anchors or Targets. These keywords are used to place and move the actions around in the tab groups. Learn more about adding, moving, and modifying actions in [Using keywords to place actions and controls](devenv-page-ext-object.md#using-keywords-to-place-actions-and-controls).
 
 > [!NOTE]  
 > Actions can only be linked to a page, or to a group control. Actions cannot be linked to fields, or parts on a page.
@@ -50,7 +50,7 @@ In order to add actions to the action bar, you must use the keywords with Anchor
 
 The following example shows how to use different action areas on a **page object of the PageType Card**. These actions will display in the following menus in the action bar. The following example uses the *legacy* syntax for promoted actions. Learn more in [Promoted actions](devenv-promoted-actions.md).
 
-1. Actions menu: The `area(Processing)` action area is used to display the action in the Actions menu. This action uses the **Promoted** and **PromotedCategory** properties in order to display the action in the promoted actions menu called **Process**.  
+1. Actions menu: The `area(Processing)` action area is used to display the action in the Actions menu. This action uses the **Promoted** and **PromotedCategory** properties to display the action in the promoted actions menu called **Process**.  
 1. New Document group: The `area(Creation)` action area is used to display the action in the **New document** group in the Actions menu. Also, this action uses the **Image** property to display a form icon instead of a default icon.
 1. Navigate menu: The `area(Navigation)` action area is used to display the action in the Navigate tab. This action and other actions in this example uses the **RunObject** property to assign a page to the action.
 1. Report menu: The `area(Reporting)` action area is used to display this action in the Report menu, and also a Group control is added as a submenu to this menu. It sets the **Caption** property to make the action group visible in the Reports menu.

--- a/dev-itpro/developer/devenv-al-profiler-overview.md
+++ b/dev-itpro/developer/devenv-al-profiler-overview.md
@@ -43,7 +43,7 @@ The AL profiler works on a snapshot of running code. Snapshot debugging is a rec
 
 ## Snapshot configuration settings
 
-In order to do any profiling on code, first, you must capture a snapshot of running code. Before doing that, you must set up a snapshot configuration in the `launch.json` file. The configuration settings depend on what type of profiling you want to perform. For more information, see [Snapshot debugging](devenv-snapshot-debugging.md) and [Launch JSON file](devenv-json-launch-file.md).
+To do any profiling on code, first, you must capture a snapshot of running code. Before doing that, you must set up a snapshot configuration in the `launch.json` file. The configuration settings depend on what type of profiling you want to perform. For more information, see [Snapshot debugging](devenv-snapshot-debugging.md) and [Launch JSON file](devenv-json-launch-file.md).
 
 ### To set up a snapshot configuration for instrumentation profiling
 

--- a/dev-itpro/developer/devenv-developing-for-multiple-platform-versions.md
+++ b/dev-itpro/developer/devenv-developing-for-multiple-platform-versions.md
@@ -24,7 +24,7 @@ The following two elements are compared when you publish an extension.
 1. The runtime version of the extension defined in the app.json file.
 2. The runtime version of the platform that the extension is targeting.
 
-In the app.json file, set the extension **runtime** version lower than the platform version. When you set the extension to a higher **runtime** version, the extension package may contain certain features that the platform may not support which would result in an error. Therefore, you must lower the extension runtime version than the one that platform supports in order to publish your extension.
+In the app.json file, set the extension **runtime** version lower than the platform version. When you set the extension to a higher **runtime** version, the extension package may contain certain features that the platform may not support which would result in an error. Therefore, you must lower the extension runtime version than the one that platform supports to publish your extension.
 
 ### Things to be aware of
 
@@ -34,7 +34,7 @@ In the app.json file, set the extension **runtime** version lower than the platf
 
 2. When you lower the extension runtime version, you may get warnings about the newest features not supported by the earlier versions of the platform.
 
-3. A best-effort compilation is made when you publish an extension compiled with a lower runtime version. This is allowed in order to avoid recompilation of the extension package every time you upgrade the platform. 
+3. A best-effort compilation is made when you publish an extension compiled with a lower runtime version. This is allowed to avoid recompilation of the extension package every time you upgrade the platform. 
 
 ## Related information
 


### PR DESCRIPTION
Three developer docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

Changes:
- `devenv-developing-for-multiple-platform-versions.md` L27: "in order to publish" to "to publish"
- `devenv-developing-for-multiple-platform-versions.md` L37: "in order to avoid recompilation" to "to avoid recompilation"
- `devenv-al-profiler-overview.md` L46: "In order to do any profiling" to "To do any profiling"
- `devenv-adding-actions-to-a-page.md` L35: "In order to add actions" to "To add actions"
- `devenv-adding-actions-to-a-page.md` L53: "in order to display the action" to "to display the action"
