### PR TITLE
Simplify 'in order to' in AppSourceCop AS0076 and tables overview docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0076.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0076.md
@@ -26,7 +26,7 @@ The ObsoleteTag [property](../properties/devenv-obsoletetag-property.md) and [at
 
 ### Enabling the rule using a ruleset
 
-The diagnostics for rule AS0076 are hidden by default, so you first have to use a [ruleset](../devenv-rule-set-syntax-for-code-analysis-tools.md) in order to surface them.
+The diagnostics for rule AS0076 are hidden by default, so you first have to use a [ruleset](../devenv-rule-set-syntax-for-code-analysis-tools.md) to surface them.
 
 For example, the following ruleset turns the diagnostic for rule AS0076 into an error.
 
@@ -50,14 +50,14 @@ For example, the following ruleset turns the diagnostic for rule AS0076 into an 
 ```
 
 > [!NOTE]  
-> In order to fully validate obsolete properties and attributes, we recommend enabling the rules [AS0072](appsourcecop-as0072.md), [AS0073](appsourcecop-as0073.md), [AS0074](appsourcecop-as0074.md), [AS0075](appsourcecop-as0075.md), and [AS0076](appsourcecop-as0076.md).
+> To fully validate obsolete properties and attributes, we recommend enabling the rules [AS0072](appsourcecop-as0072.md), [AS0073](appsourcecop-as0073.md), [AS0074](appsourcecop-as0074.md), [AS0075](appsourcecop-as0075.md), and [AS0076](appsourcecop-as0076.md).
 
 ### Setting up the AppSourceCop.json
 
 By default, the rule will validate that the specified obsolete tags are following the pattern `(\\d+)\\.(\\d+)`.
 
 However, it is possible to specify a custom pattern as a regular expression using the `obsoleteTagPattern` property in the AppSourceCop.json.
-The property `obsoleteTagPatternDescription` can be used in order to provide a human readable version of the expected pattern. 
+The property `obsoleteTagPatternDescription` can be used to provide a human readable version of the expected pattern. 
 The pattern description is used when reporting diagnostics.
 
 ```json
@@ -69,7 +69,7 @@ The pattern description is used when reporting diagnostics.
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, make sure that your obsolete tags are matching the expected `obsoleteTagPattern`.
+To fix this diagnostic, make sure that your obsolete tags are matching the expected `obsoleteTagPattern`.
 
 For instance, when using the default obsolete tag pattern, two diagnostics will be reported by rule AS0076 because the obsolete tag property and the obsolete tag attribute parameter values do not respect the format Major.Minor.
 

--- a/dev-itpro/developer/devenv-tables-overview.md
+++ b/dev-itpro/developer/devenv-tables-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Tables overview
-description: Tables are the objects in which you store and manipulate data, and you create pages and reports in order to access and view the data in the tables.
+description: Tables are the objects in which you store and manipulate data, and you create pages and reports to access and view the data in the tables.
 ms.date: 03/01/2024
 ms.topic: overview
 ms.author: solsen
@@ -11,7 +11,7 @@ ms.reviewer: solsen
 
 # Tables overview
 
-Tables are the fundamental objects in any database. They're the objects in which you store and manipulate data. This is true no matter what kind of data you need to manage. When you create a new database, you begin by building the tables. Later, you create pages and reports in order to access and view the data in the tables.  
+Tables are the fundamental objects in any database. They're the objects in which you store and manipulate data. This is true no matter what kind of data you need to manage. When you create a new database, you begin by building the tables. Later, you create pages and reports to access and view the data in the tables.  
 
 A table can be visualized as a two-dimensional matrix, consisting of columns and rows. In a table each row is a record and each column is a field. A table consists of two parts: the table data and a table description. The table data is the part users often think of as comprising the database, because it contains the actual records with their data fields. The layout and properties of those fields, however, are specified by the table description. The table description isn't directly visible to the user. The following illustration shows how the table data and the table description together form a table.  
   


### PR DESCRIPTION
Two devitpro files use "in order to" where plain "to" is more concise per Microsoft Writing Style Guide.

Changes in `appsourcecop-as0076.md` (4 instances):
- L29, L53, L60, L72: "in order to" replaced with "to"

Changes in `devenv-tables-overview.md` (2 instances):
- L3 (description front matter), L14: "in order to" replaced with "to"
