### PR TITLE
Simplify 'in order to' in AppSourceCop AS0003, AS0009, and AS0010 docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0003.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0003.md
@@ -27,7 +27,7 @@ This rule validates that the version of the extension specified as a baseline fo
 
 ### Setting up AppSourceCop to detect breaking changes
 
-In order to set up AppSourceCop to detect breaking changes, the version of the extension used as a baseline must be specified in the AppSourceCop.json file using the `version` property. The version specified is the exact version against which the breaking changes are validated. It is also possible to specify the `name` and the `publisher` of the extension in the AppSourceCop.json file. The `baselinePackageCachePath` allows you to specify the folder that will act as a cache for the baseline package and its dependencies for the AppSourceCop analyzer.
+To set up AppSourceCop to detect breaking changes, the version of the extension used as a baseline must be specified in the AppSourceCop.json file using the `version` property. The version specified is the exact version against which the breaking changes are validated. It is also possible to specify the `name` and the `publisher` of the extension in the AppSourceCop.json file. The `baselinePackageCachePath` allows you to specify the folder that will act as a cache for the baseline package and its dependencies for the AppSourceCop analyzer.
 
 If the `baselinePackageCachePath` is not specified, the baseline and its dependencies are expected to be found in the dependency package cache path. The `al.packageCachePath` setting allows you to specify the path to a folder that will act as the cache for the symbol files used by your project. This is sufficient for most scenarios, but `baselinePackageCachePath` provides a higher accuracy as it ensures that the previous version of the extension will be loaded using the right version of its dependencies.
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0009.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0009.md
@@ -27,7 +27,7 @@ It is not allowed to change the list of fields for the primary key or for the [c
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, you must revert the changes done in the current version of your extension so that the list of fields for the primary key or the clustered key matches the one defined for the key in your baseline extension.
+To fix this diagnostic, you must revert the changes done in the current version of your extension so that the list of fields for the primary key or the clustered key matches the one defined for the key in your baseline extension.
 
 ## Code examples triggering the rule
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0010.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0010.md
@@ -25,7 +25,7 @@ It is not allowed to rename the primary key because this will break upgrade of e
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, you must rename the primary key or add it back so that it matches its definition in your baseline extension.
+To fix this diagnostic, you must rename the primary key or add it back so that it matches its definition in your baseline extension.
 
 ## Code examples triggering the rule
 


### PR DESCRIPTION
Three AppSourceCop rule docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `appsourcecop-as0003.md` L30: "In order to set up" -> "To set up"
- `appsourcecop-as0009.md` L30: "In order to fix" -> "To fix"
- `appsourcecop-as0010.md` L28: "In order to fix" -> "To fix"
