### PR TITLE
Simplify 'in order to' in AppSourceCop AS0011, AS0013, AS0016, and AS0043 docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0011.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0011.md
@@ -18,7 +18,7 @@ An affix is required.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 
-In order to avoid name clashes for objects added by your extension and objects added by other extensions, an affix must be prepended or appended to the name of all new application objects, extension objects, and fields. For more information, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
+To avoid name clashes for objects added by your extension and objects added by other extensions, an affix must be prepended or appended to the name of all new application objects, extension objects, and fields. For more information, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
 
 ### Using the property mandatoryAffixes
 
@@ -38,7 +38,7 @@ The `mandatoryAffixes` property expects to receive an array of string as follows
 
 ### Using the properties mandatoryPrefix and mandatorySuffix
 
-In order to preserve backward compatibility, the properties `mandatoryPrefix` and `mandatorySuffix` are still supported by the AppSourceCop.
+To preserve backward compatibility, the properties `mandatoryPrefix` and `mandatorySuffix` are still supported by the AppSourceCop.
 
 Both properties expect to receive a string as follows:
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0013.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0013.md
@@ -20,7 +20,7 @@ The field identifier must be within the allowed range and outside the range allo
 
 ## Remarks
 
-In order to avoid ID clashes for objects added by your extension and objects added by other extensions, you must respect the ID range specified in the [app.json](../devenv-json-files.md) file of your extension when declaring new AL objects. For more information about ID ranges in Business Central, see [Object Ranges](../devenv-object-ranges.md).
+To avoid ID clashes for objects added by your extension and objects added by other extensions, you must respect the ID range specified in the [app.json](../devenv-json-files.md) file of your extension when declaring new AL objects. For more information about ID ranges in Business Central, see [Object Ranges](../devenv-object-ranges.md).
 
 The following illustrates an example of an `app.json` file specifying an ID range:
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0016.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0016.md
@@ -28,7 +28,7 @@ also validated by this rule.
 
 ## How to fix this diagnostic?
 
-In order to fix the diagnostics reported you must set the [DataClassification](../properties/devenv-dataclassification-property.md) property on the table fields in your extension following the guidelines defined in [Classifying Data in Dynamics 365](../devenv-classifying-data.md).
+To fix the diagnostics reported you must set the [DataClassification](../properties/devenv-dataclassification-property.md) property on the table fields in your extension following the guidelines defined in [Classifying Data in Dynamics 365](../devenv-classifying-data.md).
 
 ## Code examples triggering the rule
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0043.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0043.md
@@ -25,7 +25,7 @@ It's not allowed to rename or remove the clustered key in a table. For more info
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, you must rename the clustered key or add it back so that it matches its definition in your baseline extension.
+To fix this diagnostic, you must rename the clustered key or add it back so that it matches its definition in your baseline extension.
 
 ## Code examples triggering the rule
 


### PR DESCRIPTION
Four AppSourceCop rule docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `appsourcecop-as0011.md` L21, L41: two instances replaced
- `appsourcecop-as0013.md` L23: one instance replaced
- `appsourcecop-as0016.md` L31: one instance replaced
- `appsourcecop-as0043.md` L28: one instance replaced
