### PR TITLE
Simplify 'in order to' in AppSourceCop AS0024, AS0029, and AS0031 docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0024.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0024.md
@@ -96,8 +96,8 @@ codeunit 50120 AnotherCodeunit
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, the changes on the procedure signature must be reverted. The procedure should be marked as obsolete, and a new procedure should be introduced.
-The behavior of the obsoleted procedure should be preserved in order to not break the runtime behavior of dependent extensions while they have not yet uptaken the new procedure.
+To fix this diagnostic, the changes on the procedure signature must be reverted. The procedure should be marked as obsolete, and a new procedure should be introduced.
+The behavior of the obsoleted procedure should be preserved to not break the runtime behavior of dependent extensions while they have not yet uptaken the new procedure.
 
 ### Example - Adding a parameter to a public procedure
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0029.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0029.md
@@ -31,7 +31,7 @@ It's not allowed to remove pages which have been published unless they have been
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, the removal of the page extension must be reverted. The page extension should also be marked as [Obsolete](../properties/devenv-obsoletestate-property.md) instead, so that the page extension can be removed in a future version.
+To fix this diagnostic, the removal of the page extension must be reverted. The page extension should also be marked as [Obsolete](../properties/devenv-obsoletestate-property.md) instead, so that the page extension can be removed in a future version.
 
 ## Examples not triggering the rule
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0031.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0031.md
@@ -32,9 +32,9 @@ Removing an action, which has been published isn't allowed because it will break
 
 If the action was removed, revert the change by adding back the action and mark it as [Obsolete](../properties/devenv-obsoletestate-property.md).
 
-If the action was renamed in order to change its display string in the web client, consider using the [Caption](../properties/devenv-caption-property.md) property instead.
+If the action was renamed to change its display string in the web client, consider using the [Caption](../properties/devenv-caption-property.md) property instead.
 
-If the action was renamed in order to comply with naming rules such as [AS0011](appsourcecop-as0011.md), consider obsoleting the action before introducing a new one in the next version of the app.
+If the action was renamed to comply with naming rules such as [AS0011](appsourcecop-as0011.md), consider obsoleting the action before introducing a new one in the next version of the app.
 
 If the [Promoted](../properties/devenv-promoted-property.md) property was removed or set to false on an action, consider obsoleting the action before modifying the promoted property in the next version of the app.
 


### PR DESCRIPTION
Three AppSourceCop rule docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `appsourcecop-as0024.md` L99, L100: two instances replaced
- `appsourcecop-as0029.md` L34: one instance replaced
- `appsourcecop-as0031.md` L35, L37: two instances replaced
