### PR TITLE
Simplify 'in order to' in AppSourceCop AS0032, AS0033, and AS0054 docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0032.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0032.md
@@ -28,9 +28,9 @@ Removing a control which has been published is not allowed because it will break
 
 If the control was removed, revert the change by adding back the control and mark it as [Obsolete](../properties/devenv-obsoletestate-property.md).
 
-If the control was renamed in order to change its display string in the web client, consider using the [Caption](../properties/devenv-caption-property.md) property instead.
+If the control was renamed to change its display string in the web client, consider using the [Caption](../properties/devenv-caption-property.md) property instead.
 
-If the control was renamed in order to comply with naming rules such as [AS0011](appsourcecop-as0011.md), consider obsoleting the control and introducing a new one.
+If the control was renamed to comply with naming rules such as [AS0011](appsourcecop-as0011.md), consider obsoleting the control and introducing a new one.
 
 ## Examples of errors for dependent extensions
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0033.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0033.md
@@ -28,9 +28,9 @@ Removing a view which has been published is not allowed because it will break de
 
 If the view was removed, revert the change by adding back the view and mark it as [Obsolete](../properties/devenv-obsoletestate-property.md).
 
-If the view was renamed in order to change its display string in the web client, consider using the [Caption](../properties/devenv-caption-property.md) property instead.
+If the view was renamed to change its display string in the web client, consider using the [Caption](../properties/devenv-caption-property.md) property instead.
 
-If the view was renamed in order to comply with naming rules such as [AS0011](appsourcecop-as0011.md), consider obsoleting the view and introducing a new one.
+If the view was renamed to comply with naming rules such as [AS0011](appsourcecop-as0011.md), consider obsoleting the view and introducing a new one.
 
 ## Examples of errors for dependent extensions
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0054.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0054.md
@@ -34,7 +34,7 @@ For more information, see [AppSourceCop Rule AS0011](appsourcecop-as0011.md).
 
 The use of affixes is required for extensions submitted to the AppSource marketplace, see [Technical Validation Checklist](../devenv-checklist-submission.md).
 
-In order to register your affixes, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
+To register your affixes, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
 
 ## Related information  
 


### PR DESCRIPTION
Three AppSourceCop rule docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `appsourcecop-as0032.md` L31, L33: two instances replaced
- `appsourcecop-as0033.md` L31, L33: two instances replaced
- `appsourcecop-as0054.md` L37: one instance replaced
