### PR TITLE
Simplify 'in order to' in AppSourceCop AS0073, AS0079, and AS0085 docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0073.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0073.md
@@ -26,7 +26,7 @@ The format of the Obsolete tag is not validated by the AL compiler. However, you
 
 ## Setting up AppSourceCop to validate the Obsolete Tag
 
-The diagnostics for rule AS0073 are hidden by default, so you first have to use a [ruleset](../devenv-rule-set-syntax-for-code-analysis-tools.md) in order to surface them.
+The diagnostics for rule AS0073 are hidden by default, so you first have to use a [ruleset](../devenv-rule-set-syntax-for-code-analysis-tools.md) to surface them.
 
 For example, the following ruleset turns the diagnostic for rule AS0073 into an error.
 
@@ -50,7 +50,7 @@ For example, the following ruleset turns the diagnostic for rule AS0073 into an 
 ```
 
 > [!NOTE]  
-> In order to fully validate obsolete properties and attributes, it is recommended to enable the rules [AS0072](appsourcecop-as0072.md), [AS0073](appsourcecop-as0073.md), [AS0074](appsourcecop-as0074.md), [AS0075](appsourcecop-as0075.md), and [AS0076](appsourcecop-as0076.md).
+> To fully validate obsolete properties and attributes, it is recommended to enable the rules [AS0072](appsourcecop-as0072.md), [AS0073](appsourcecop-as0073.md), [AS0074](appsourcecop-as0074.md), [AS0075](appsourcecop-as0075.md), and [AS0076](appsourcecop-as0076.md).
 
 ## How to fix this diagnostic?
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0079.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0079.md
@@ -20,7 +20,7 @@ An affix is required for procedures defined in extension objects, because it pre
 
 ## Remarks
 
-In order to avoid name clashes for procedures added by your extension objects (i.e table extension, page extension) and procedures added by other extensions, an affix must be prepended or appended to the name of all new procedures in extension objects, extension objects, and fields. For more information, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
+To avoid name clashes for procedures added by your extension objects (i.e table extension, page extension) and procedures added by other extensions, an affix must be prepended or appended to the name of all new procedures in extension objects, extension objects, and fields. For more information, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
 
 ## How to fix this diagnostic?
 

--- a/dev-itpro/developer/analyzers/appsourcecop-as0085.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0085.md
@@ -28,7 +28,7 @@ For more information about the properties in the `app.json`, see [JSON files](..
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, you have to replace the dependencies specifed on the 'Base Application' and 'System Application'  in the `dependencies` property by the `application` property in the `app.json` of the extension.
+To fix this diagnostic, you have to replace the dependencies specifed on the 'Base Application' and 'System Application'  in the `dependencies` property by the `application` property in the `app.json` of the extension.
 
 ## Code example triggering the rule
 


### PR DESCRIPTION
Three AppSourceCop rule docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `appsourcecop-as0073.md` L29, L53: two instances replaced
- `appsourcecop-as0079.md` L23: one instance replaced
- `appsourcecop-as0085.md` L31: one instance replaced
