### PR TITLE
Simplify 'in order to' in AppSourceCop AS0096, AS0097, AS0098, and AS0099 docs

### DIFF
--- a/dev-itpro/developer/analyzers/appsourcecop-as0096.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0096.md
@@ -24,7 +24,7 @@ Changing the identity of extensions is only supported in Business Central starti
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, you must either:
+To fix this diagnostic, you must either:
 
 - change the name of the extension in the app.json to match the name used in the baseline,
 - update the runtime version in the app.json to be 8.0 or higher.

--- a/dev-itpro/developer/analyzers/appsourcecop-as0097.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0097.md
@@ -24,7 +24,7 @@ Changing the identity of extensions is only supported in Business Central starti
 
 ## How to fix this diagnostic?
 
-In order to fix this diagnostic, you must either:
+To fix this diagnostic, you must either:
 
 - change the publisher of the extension in the app.json to match the publisher name used in the baseline,
 - update the runtime version in the app.json to be 8.0 or higher.

--- a/dev-itpro/developer/analyzers/appsourcecop-as0098.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0098.md
@@ -18,7 +18,7 @@ An affix is needed.
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 
-In order to avoid name clashes for objects added by your extension and objects added by other extensions, an affix must be prepended or appended to the name of all new application objects, extension objects, and fields. For more information, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
+To avoid name clashes for objects added by your extension and objects added by other extensions, an affix must be prepended or appended to the name of all new application objects, extension objects, and fields. For more information, see [Benefits and Guidelines for using a Prefix or Suffix](../../compliance/apptest-prefix-suffix.md).
 
 > [!NOTE]  
 > This rule mimics the behavior of [AS0011](appsourcecop-as0011.md) for a limited set of objects members for which AS0011 wasn't enforced when they were introduced in AL. Having them reported as a separate rule allows more granularity, especially in regard to AL code not respecting the use of affixes prior to the implementation of this rule.

--- a/dev-itpro/developer/analyzers/appsourcecop-as0099.md
+++ b/dev-itpro/developer/analyzers/appsourcecop-as0099.md
@@ -18,7 +18,7 @@ The member ID should be within the allowed range and outside the range allocated
 
 [//]: # (IMPORTANT: END>DO_NOT_EDIT)
 
-In order to avoid ID clashes for objects added by your extension and objects added by other extensions, you must respect the ID range specified in the [app.json](../devenv-json-files.md) file of your extension when declaring new AL objects. For more information on ID ranges in Business Central, see [Object Ranges](../devenv-object-ranges.md).
+To avoid ID clashes for objects added by your extension and objects added by other extensions, you must respect the ID range specified in the [app.json](../devenv-json-files.md) file of your extension when declaring new AL objects. For more information on ID ranges in Business Central, see [Object Ranges](../devenv-object-ranges.md).
 
 > [!NOTE]  
 > This rule mimics the behavior of [AS0013](appsourcecop-as0013.md) for a limited set of objects members for which AS0013 wasn't enforced when they were introduced in AL. Having them reported as a separate rule allows more granularity, especially in regards to AL code not respecting the use of affixes prior to the implementation of this rule.


### PR DESCRIPTION
Four AppSourceCop rule docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `appsourcecop-as0096.md` L27: one instance replaced
- `appsourcecop-as0097.md` L27: one instance replaced
- `appsourcecop-as0098.md` L21: one instance replaced
- `appsourcecop-as0099.md` L21: one instance replaced
