### PR TITLE
Simplify 'in order to' in PTE, UICop, and CodeCop analyzer docs

### DIFF
--- a/dev-itpro/developer/analyzers/codecop-aa0470.md
+++ b/dev-itpro/developer/analyzers/codecop-aa0470.md
@@ -20,7 +20,7 @@ Provide an explanation that describes the content of each of the placeholders.
 
 ## Reason for the rule
 
-Documentation of placeholders is required in order to enable translators to properly know the construct of the label to be translated.
+Documentation of placeholders is required to enable translators to properly know the construct of the label to be translated.
 
 ## Bad code example
 ```AL

--- a/dev-itpro/developer/analyzers/pertenantextensioncop-pte0001.md
+++ b/dev-itpro/developer/analyzers/pertenantextensioncop-pte0001.md
@@ -24,7 +24,7 @@ This rule validates that all the object IDs defined in your extension are within
 
 ## How to fix this diagnostic?
 
-You must change the ID of the object or table field validated in order to use an ID within the range 50,000-99,999.
+You must change the ID of the object or table field validated to use an ID within the range 50,000-99,999.
 
 ## Code example triggering the rule
 

--- a/dev-itpro/developer/analyzers/pertenantextensioncop-pte0002.md
+++ b/dev-itpro/developer/analyzers/pertenantextensioncop-pte0002.md
@@ -27,7 +27,7 @@ This rule validates that all table field IDs defined in your extension are withi
 
 ## How to fix this diagnostic?
 
-You must change the ID of the object or table field validated in order to use an ID within the range 50,000-99,999.
+You must change the ID of the object or table field validated to use an ID within the range 50,000-99,999.
 
 ## Code examples triggering the rule
 

--- a/dev-itpro/developer/analyzers/uicop-aw0014.md
+++ b/dev-itpro/developer/analyzers/uicop-aw0014.md
@@ -115,7 +115,7 @@ page 50100 MyPage
 
 There's no impact on the default section of the command bar since all actions remain hidden by the group. However, the actionref no longer appears in the promoted section of the command bar. Use this approach if you didn't expect `MyPromotedAction` to appear in the promoted section of the command bar and you want to hide it completely. 
 
-Remark, in order to be compliant with the breaking change validation from the [AppSourceCop](appsourcecop.md), the following change is recommended:
+Remark, to be compliant with the breaking change validation from the [AppSourceCop](appsourcecop.md), the following change is recommended:
 
 ```al
 page 50100 MyPage


### PR DESCRIPTION
Four analyzer docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `pertenantextensioncop-pte0001.md` L27: one instance replaced
- `pertenantextensioncop-pte0002.md` L30: one instance replaced
- `uicop-aw0014.md` L118: one instance replaced
- `codecop-aa0470.md` L23: one instance replaced
