### PR TITLE
Simplify 'in order to' in AppSource checklist submission docs

### DIFF
--- a/dev-itpro/developer/devenv-checklist-submission-app-identity.md
+++ b/dev-itpro/developer/devenv-checklist-submission-app-identity.md
@@ -29,7 +29,7 @@ When changing the publisher of an extension, you must:
 
 - increment the version number in the manifest of your extension,
 - make sure that your submission only targets releases of [!INCLUDE[prod_short](../includes/prod_short.md)] starting from 19.0,
-- contact d365val@microsoft.com in order to register your affixes to your new publisher name.
+- contact d365val@microsoft.com to register your affixes to your new publisher name.
 
 ## When is it okay to change the App ID of my extension?
 

--- a/dev-itpro/developer/devenv-checklist-submission-app-preview.md
+++ b/dev-itpro/developer/devenv-checklist-submission-app-preview.md
@@ -23,7 +23,7 @@ Preview versions can be installed on Sandbox environments running on [!INCLUDE[p
 
 ## How can I install preview versions for selected customers?
 
-Selected customers can install the preview version of the extensions in your submission after the "Preview creation" step of the submission flow in Partner Center. In order to trigger the install, customers must receive and use the preview app install URL:
+Selected customers can install the preview version of the extensions in your submission after the "Preview creation" step of the submission flow in Partner Center. To trigger the install, customers must receive and use the preview app install URL:
 
 `https://businesscentral.dynamics.com/[TenantID]/?noSignUpCheck=1&filter='ID' IS '[AppID]' AND 'PreviewKey' IS '[PreviewKey]'&page=2503` 
 

--- a/dev-itpro/developer/devenv-checklist-submission.md
+++ b/dev-itpro/developer/devenv-checklist-submission.md
@@ -196,7 +196,7 @@ For Marketplace extensions, it's now required to use the `application` property 
 
 <!-- ### How to specify a maximum release for your extension?
 
-In order to specify the maximum release for your extension, you must include a file named `submissionManifest.json` along with your libraries in Partner Center. This submission manifest allows you to specify the release for which your extension should stop being validated.
+To specify the maximum release for your extension, you must include a file named `submissionManifest.json` along with your libraries in Partner Center. This submission manifest allows you to specify the release for which your extension should stop being validated.
 
 For instance, the following submission manifest indicates that the extension will be validated for all releases versions from the minimum release version until 18.0 excluded. If the minimum release for the submission is 17.3, this means that this extension will be validated for 17.3, 17.4, and 17.5.
 


### PR DESCRIPTION
Three AppSource submission checklist docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `devenv-checklist-submission.md` L199: one instance replaced (inside commented-out section)
- `devenv-checklist-submission-app-identity.md` L32: one instance replaced
- `devenv-checklist-submission-app-preview.md` L26: one instance replaced
