### PR TITLE
Simplify 'in order to' in actions, FlowFields, data transfer, and deprecation docs

### DIFF
--- a/dev-itpro/developer/devenv-actions-overview.md
+++ b/dev-itpro/developer/devenv-actions-overview.md
@@ -35,7 +35,7 @@ For more information about actions used on the role center page, see [Designing 
  
 ## Types of actions
 
-Each page has a different set of actions depending on the page type, and the processes that the page supports. In order to create the appropriate set of actions for a particular page, you should have a good understanding of your customer's business processes.  
+Each page has a different set of actions depending on the page type, and the processes that the page supports. To create the appropriate set of actions for a particular page, you should have a good understanding of your customer's business processes.  
   
 Each process in an organization has several actions associated with it. You should try to create a full set of actions that mirror all tasks and processes that are performed.  
   

--- a/dev-itpro/developer/devenv-creating-flowfields-and-flowfilters.md
+++ b/dev-itpro/developer/devenv-creating-flowfields-and-flowfilters.md
@@ -23,7 +23,7 @@ A typical scenario for using a FlowField could be the Account Balance field in t
 
 ## Classifying the field type
 
-In order to create FlowFields and FlowFilters, you must first classify the field type by using the FieldClass Property. For more information, see [FieldClass Property](properties/devenv-fieldclass-property.md). By classifying the field as a FlowField or a FlowFilter type, you enable the fields to act as a virtual field whose value can be dynamically derived based on the calculation formula. 
+To create FlowFields and FlowFilters, you must first classify the field type by using the FieldClass Property. For more information, see [FieldClass Property](properties/devenv-fieldclass-property.md). By classifying the field as a FlowField or a FlowFilter type, you enable the fields to act as a virtual field whose value can be dynamically derived based on the calculation formula. 
 
 ## Calculation formula
 

--- a/dev-itpro/developer/devenv-data-transfer.md
+++ b/dev-itpro/developer/devenv-data-transfer.md
@@ -155,7 +155,7 @@ The join condition can be specified on arbitrary fields, which leaves the possib
 
 ### Example 2 - replace ModifyAll()
 
-In order to replace a Record.ModifyAll() with the DataTransfer data type, ensure that only one table is set (as both source and destination), apply filters if required, and then specify one or more new field values:
+To replace a Record.ModifyAll() with the DataTransfer data type, ensure that only one table is set (as both source and destination), apply filters if required, and then specify one or more new field values:
 
 ```AL
 local procedure CopyFieldsReplacingModifyAll()

--- a/dev-itpro/developer/devenv-deprecation-guidelines.md
+++ b/dev-itpro/developer/devenv-deprecation-guidelines.md
@@ -109,7 +109,7 @@ When we obsolete code, we:
         #endif
         ```
 
-In order to have the compiler take the new ‘clean’ code path, symbols must be defined. The symbols are defined in the `app.json` file with the following setting. Learn more in [JSON files](devenv-json-files.md).
+To have the compiler take the new ‘clean’ code path, symbols must be defined. The symbols are defined in the `app.json` file with the following setting. Learn more in [JSON files](devenv-json-files.md).
 
 ```al
 "preprocessorSymbols": [ "CLEAN15", "CLEAN16", "CLEAN17", "CLEAN18" ]


### PR DESCRIPTION
Four developer docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `devenv-actions-overview.md` L38: one instance replaced
- `devenv-creating-flowfields-and-flowfilters.md` L26: one instance replaced
- `devenv-data-transfer.md` L158: one instance replaced
- `devenv-deprecation-guidelines.md` L112: one instance replaced
