### PR TITLE
Simplify 'in order to' in e-documents, extensible enums, scope, and RDL report docs

### DIFF
--- a/dev-itpro/developer/devenv-extend-edocuments.md
+++ b/dev-itpro/developer/devenv-extend-edocuments.md
@@ -22,7 +22,7 @@ Additionally, when you explore the **Service Integration** option, you find seve
 
 ## Develop an e-documents extension  
 
-In order to implement your localization or other extension on top of the **E-Document Core** application, you should perform the following procedures.  
+To implement your localization or other extension on top of the **E-Document Core** application, you should perform the following procedures.  
 
 ### Create and set up a new extension
 

--- a/dev-itpro/developer/devenv-extensible-enums.md
+++ b/dev-itpro/developer/devenv-extensible-enums.md
@@ -48,7 +48,7 @@ enum 50121 Loyalty
 
 ## Enumextension object
 
-Enums can be extended in order to add more values to the enumeration list in which case the `Extensible` property must be set to `true`. The syntax for an enum extension, which extends the **Loyalty** enum with the value **Diamond**, is shown below.
+Enums can be extended to add more values to the enumeration list in which case the `Extensible` property must be set to `true`. The syntax for an enum extension, which extends the **Loyalty** enum with the value **Diamond**, is shown below.
 
 ```AL
 enumextension 50130 LoyaltyWithDiamonds extends Loyalty

--- a/dev-itpro/developer/devenv-extension-moving-scope.md
+++ b/dev-itpro/developer/devenv-extension-moving-scope.md
@@ -122,7 +122,7 @@ You can find the full list of requirements for PTE in the documentation for the 
 
 - Marketplace apps and PTEs are using different ID ranges. You must then change the ID of all the objects in your extension. For more information, see [Object Ranges](devenv-object-ranges.md).
 
-- In order to avoid potential name conflicts if the Marketplace app and the PTE are installed side-by-side, it's recommend changing the name of all the objects in your extension.
+- To avoid potential name conflicts if the Marketplace app and the PTE are installed side-by-side, it's recommend changing the name of all the objects in your extension.
 
 - You can find the full list of requirements for PTE in the documentation for the [PerTenantExtensionCop Analyzer](analyzers/pertenantextensioncop.md).
 

--- a/dev-itpro/developer/devenv-howto-rdl-report-layout.md
+++ b/dev-itpro/developer/devenv-howto-rdl-report-layout.md
@@ -98,7 +98,7 @@ Specifically for RDL layouts, there are many ways to control formatting of data 
 
 If you've created a [Rich Text content control](devenv-richtext-content-controls.md), you can display the text on an RDL report. This means that you can display multi-line formatted text, emphasize important points, and have clickable hyperlinks.
 
-Rich Text is stored as HTML within the database. In order to display the formatted HTML, you need to change the `Placeholder Properties` within your RDL.
+Rich Text is stored as HTML within the database. To display the formatted HTML, you need to change the `Placeholder Properties` within your RDL.
 
 1. After adding the field to your report layout that contains the Rich Text, left-click on the field so that the `<Expr>` tag is highlighted.
 


### PR DESCRIPTION
Four developer docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

- `devenv-extend-edocuments.md` L25: one instance replaced
- `devenv-extensible-enums.md` L51: one instance replaced
- `devenv-extension-moving-scope.md` L125: one instance replaced
- `devenv-howto-rdl-report-layout.md` L101: one instance replaced
