### PR TITLE
Update explanation of FindSet method behavior

### DIFF
--- a/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
@@ -45,9 +45,9 @@ You should use this method only when you explicitly want to loop through a recor
 
 The difference between `Find()` and `FindSet` is that `Find` uses paging and the method only requests N rows in the first request, and then if you need more rows, it'll submit a new SQL request. The `FindSet` method will request all rows at once. 
 
-The difference between `FindSet(false)` and `FindSet(true)` is that `FindSet(true)` will apply `Updlock` isolation level to find rows, which is an advantage if you plan to update all the rows you are finding.
+The difference between `FindSet(false)` and `FindSet(true)` is that `FindSet(true)` reads the records using `IsolationLevel::UpdLock` (SQL `UPDLOCK`), which is an advantage if you plan to update all the rows you are finding.
 
-This method works the same way as the [FindSet Method (RecordRef)](../recordref/recordref-findset-method.md).
+This method works the same way as the [FindSet Method (RecordRef)](../recordref/recordref-findset-boolean-method.md).
 
 ## Examples
 

--- a/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
+++ b/dev-itpro/developer/methods-auto/record/record-findset-boolean-method.md
@@ -45,7 +45,7 @@ You should use this method only when you explicitly want to loop through a recor
 
 The difference between `Find()` and `FindSet` is that `Find` uses paging and the method only requests N rows in the first request, and then if you need more rows, it'll submit a new SQL request. The `FindSet` method will request all rows at once. 
 
-The difference between `FindSet(false)` and `FindSet(true)` is that `FindSet(true)` will do a `LockTable()` before finding rows, which is an advantage if you plan to update all the rows you are finding.
+The difference between `FindSet(false)` and `FindSet(true)` is that `FindSet(true)` will apply `Updlock` isolation level to find rows, which is an advantage if you plan to update all the rows you are finding.
 
 This method works the same way as the [FindSet Method (RecordRef)](../recordref/recordref-findset-method.md).
 


### PR DESCRIPTION
Since version 24.x findset(true) no longer issue a Locktable(); before findest() but apply a Record.ReadIsolation(IsolationLevel::Updlock); before findset. This is a very significative changes since all subsequent access to the database, before the end of transaction or explicit commit, will not be performed in Updlock but with a more appropriate isolation level.