### PR TITLE
Document that Data-Access-Intent can change methods advertised by OPTIONS

### DIFF
--- a/dev-itpro/developer/devenv-connect-apps-tips.md
+++ b/dev-itpro/developer/devenv-connect-apps-tips.md
@@ -89,7 +89,10 @@ By specifying HTTP request header `Data-Access-Intent`, it's possible to overrid
 
 When request header is specified, the value of the DataAccessIntent property defined on the object, if any, is ignored. Overrides that are specified on the page **9880 Database Access Intent List**  take higher precedence than the value in the request header.
 
-Modification requests (like POST, PUT, or DELETE) only support `ReadWrite` as a value for data access intent. Trying to specify `Data-Access-Intent: ReadOnly` for such requests will result in an error.
+Modification requests (like `POST`, `PATCH`, `PUT`, or `DELETE`) only support `ReadWrite` as a value for data access intent. Trying to specify `Data-Access-Intent: ReadOnly` for such requests will result in an error.
+
+> [!NOTE]
+> In Business Central online, the methods advertised by an `OPTIONS` request for the same API endpoint can depend on the request's `Data-Access-Intent` header. For example, `ReadOnly` can produce an `Allow` header that excludes modification methods that are advertised when the header is omitted or set to `ReadWrite`. Include this header when comparing endpoint capabilities or troubleshooting unexpected method availability.
 
 ### Example
 


### PR DESCRIPTION
### Summary

This change documents a behavior that is easy to misdiagnose: for the same Business Central API URL, the methods advertised by `OPTIONS` can change with the `Data-Access-Intent` request header. In other words, capability discovery is request-context dependent and is not solely a property of the URL.

It also adds `PATCH` to the existing examples of modification requests.

### Why this clarification matters

With `Data-Access-Intent: ReadOnly`, the observed `Allow` header advertised only `GET` and `OPTIONS`. With the header omitted or set to `ReadWrite`, the same standard endpoint advertised `DELETE`, `GET`, `OPTIONS`, `PATCH`, `POST`, and `PUT`.

Without this distinction, two requests to the same URL can appear to expose different endpoint capabilities. That can send a root-cause investigation toward credentials, permissions, version differences, or routing even when the immediate difference is the request header. Those remain valid causes in other cases; this clarification makes `Data-Access-Intent` an explicit early check when method availability differs.

### Documentation change

- Format the modification-method examples as code and include `PATCH`.
- Add a note that `Data-Access-Intent` can affect the methods advertised by `OPTIONS` for the same API endpoint.
- Recommend comparing the request header when troubleshooting unexpected method availability.

### Reproduction evidence

The behavior was captured twice with identical results against:

- Business Central online version `28.0.52495.0`
- Standard API v2.0 `customers` endpoint
- The same API URL and authentication configuration for each intent variant
- Python 3.12 `urllib.request`, preserving repeated response headers through `raw_items()`

Each full run executed the following 14 cases:

| Method | Data-Access-Intent | Status | Error code | OPTIONS Allow |
| --- | --- | ---: | --- | --- |
| `GET` | omitted | 200 | — | — |
| `GET` | `ReadOnly` | 200 | — | — |
| `GET` | `ReadWrite` | 200 | — | — |
| `OPTIONS` | omitted | 200 | — | `DELETE, GET, OPTIONS, PATCH, POST, PUT` |
| `OPTIONS` | `ReadOnly` | 200 | — | `GET, OPTIONS` |
| `OPTIONS` | `ReadWrite` | 200 | — | `DELETE, GET, OPTIONS, PATCH, POST, PUT` |
| `POST` | `ReadOnly` | 405 | `BadRequest_MethodNotAllowed` | — |
| `POST` | omitted | 201 | — | — |
| `PATCH` | `ReadOnly` | 405 | `BadRequest_MethodNotAllowed` | — |
| `PATCH` | omitted | 200 | — | — |
| `PUT` | `ReadOnly` | 405 | `BadRequest_MethodNotAllowed` | — |
| `PUT` | omitted | 200 | — | — |
| `DELETE` | `ReadOnly` | 400 | `BadRequest` | — |
| `DELETE` | omitted | 204 | — | — |

Both runs completed successfully, including cleanup of the synthetic record. The generated evidence was sanitized and checked for sensitive values.

### Scope and limitations

- The evidence covers the standard API v2.0 `customers` endpoint on the stated Business Central online version.
- The documentation uses `can` intentionally; it does not claim that every endpoint, version, or deployment exposes an identical method set.
- The observed status codes support this reproduction and are not presented as a universal API contract.
- The `Allow` values in the table came from `OPTIONS` responses. The captured `405` responses did not contain an `Allow` header.
- This change does not imply that credentials, permissions, version, or routing can never cause method-availability differences.

### References

- [Tips for working with the APIs](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-connect-apps-tips)
- [RFC 9110: OPTIONS](https://www.rfc-editor.org/rfc/rfc9110.html#name-options) and [Allow](https://www.rfc-editor.org/rfc/rfc9110.html#name-allow)
