### PR TITLE
Update documentation for installOrUpdateNeededDependencies

### DIFF
--- a/dev-itpro/administration/administration-center-api_app_management.md
+++ b/dev-itpro/administration/administration-center-api_app_management.md
@@ -60,7 +60,7 @@ POST /admin/{apiVersion}/applications/{applicationFamily}/environments/{environm
   "targetVersion": string, // Optional. If not provided, latest version will be installed. Required if "allowPreviewVersion": true 
   "useEnvironmentUpdateWindow": boolean, // If true, the operation will be executed only in the environment update window. It will appear as "scheduled" before it runs in the window. 
   "allowPreviewVersion": boolean, // If "allowPreviewVersion": true, targetVersion is required. Applies only to apps published as part of the Embed ISV program.
-  "installOrUpdateNeededDependencies": boolean, // Value indicating whether any other app dependencies should be installed or updated. Dependencies are installed or updated to the latest version compatible with the environment, not to the minimum version required. If false, information about missing app dependencies is returned as error details
+  "installOrUpdateNeededDependencies": boolean, // Value indicating whether any other app dependencies should be installed or updated. Dependencies are installed or updated to the latest version compatible with the environment, not to the minimum version required by the app. If false, information about missing app dependencies is returned as error details.
   "acceptIsvEula": boolean, // Must be true for installation to proceed. Setting this to true means you agree to the terms described in the acceptIsvEula section that follows.
   "languageId": string // Optional. Specifies locale ID language code, for example, "en-US". This setting corresponds to what the user can set in Extension Management page in tenant.Full list of values can be found in /openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a under BCP 47 Code column 
 } 

--- a/dev-itpro/administration/administration-center-api_app_management.md
+++ b/dev-itpro/administration/administration-center-api_app_management.md
@@ -60,7 +60,7 @@ POST /admin/{apiVersion}/applications/{applicationFamily}/environments/{environm
   "targetVersion": string, // Optional. If not provided, latest version will be installed. Required if "allowPreviewVersion": true 
   "useEnvironmentUpdateWindow": boolean, // If true, the operation will be executed only in the environment update window. It will appear as "scheduled" before it runs in the window. 
   "allowPreviewVersion": boolean, // If "allowPreviewVersion": true, targetVersion is required. Applies only to apps published as part of the Embed ISV program.
-  "installOrUpdateNeededDependencies": boolean, // Value indicating whether any other app dependencies should be installed or updated; otherwise, information about missing app dependencies will be returned as error details 
+  "installOrUpdateNeededDependencies": boolean, // Value indicating whether any other app dependencies should be installed or updated. Dependencies are installed or updated to the latest version compatible with the environment, not to the minimum version required. If false, information about missing app dependencies is returned as error details
   "acceptIsvEula": boolean, // Must be true for installation to proceed. Setting this to true means you agree to the terms described in the acceptIsvEula section that follows.
   "languageId": string // Optional. Specifies locale ID language code, for example, "en-US". This setting corresponds to what the user can set in Extension Management page in tenant.Full list of values can be found in /openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a under BCP 47 Code column 
 } 
@@ -139,7 +139,7 @@ POST /admin/{apiVersion}/applications/{applicationFamily}/environments/{environm
   "syncMode": string, // Optional. Determines the sync mode applied during install. Possible values are "Add" and "ForceSync". Defaults to "Add" if omitted from request.
   "languageId": string, // Optional. Microsoft Language Code ID (for example, "en-US"). Defaults to "en-US" if omitted from request.
   "acceptIsvEula": boolean, // Required. Must be true for installation to proceed. Setting this to true means you agree to the terms described in the acceptIsvEula section that follows.
-  "installOrUpdateNeededDependencies": boolean // Optional. Determines whether dependencies of the uploaded extension should be automatically installed or updated; otherwise the install fails when dependencies are missing. Defaults to false if omitted from request.
+  "installOrUpdateNeededDependencies": boolean // Optional. Determines whether dependencies of the uploaded extension are automatically installed or updated; otherwise the install fails when dependencies are missing. Dependencies are installed or updated to the latest version compatible with the environment, not to the minimum version the extension declares. Defaults to false if omitted from request.
 } 
 ```
 
@@ -397,7 +397,7 @@ POST /admin/{apiVersion}/applications/{applicationFamily}/environments/{environm
   "useEnvironmentUpdateWindow": boolean, // If set to true, the operation will be executed only in the environment update window. It will appear as "scheduled" before it runs in the window.
   "targetVersion": string, // Always required. There's no option to update to the latest. You have to first do a "availableAppUpdates", call then use the version here.
   "allowPreviewVersion": boolean,  
-  "installOrUpdateNeededDependencies": boolean // Value indicating whether any other app dependencies should be installed or updated; otherwise, information about missing app dependencies will be returned as error details
+  "installOrUpdateNeededDependencies": boolean // Value indicating whether any other app dependencies should be installed or updated. Dependencies are installed or updated to the latest version compatible with the environment, not to the minimum version required by the app. If false, information about missing app dependencies is returned as error details
 }
 ```
 


### PR DESCRIPTION
Clarified the behavior of 'installOrUpdateNeededDependencies' to specify that dependencies are updated to the latest compatible version, not just the minimum required version.

Verified on a sandbox environment: I scripted an install of an older version of the dependency app, then ran /apps/{appId}/update on the dependent app with installOrUpdateNeededDependencies: true. The dependency was updated to the latest version compatible with the environment rather than to the version named in the requirements payload, which is what the current wording implies.